### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-release:
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/jonathanmagambo/otterlang/security/code-scanning/1](https://github.com/jonathanmagambo/otterlang/security/code-scanning/1)

To address this problem, we need to explicitly specify the required `permissions` for the GitHub Actions workflow, following the principle of least privilege. The job uploading artifacts does not require special permissions, but the "Create GitHub Release" step (using `softprops/action-gh-release@v1`) requires `contents: write` permission to create or update a release on GitHub. Therefore, the minimal correct permissions block is `contents: write`.

This can be placed at the workflow root (to apply to all jobs by default), or at the job level (if you want to restrict `contents: write` to only this job, which is the only one defined). Since only one job (`build-release`) exists, place it at the job level for clarity and future maintenance.

**What to do:**  
- In `.github/workflows/release.yml`, at the same level as `strategy:`, `runs-on:`, and `steps:` under `build-release:`, add:  
  ```yaml
  permissions:
    contents: write
  ```
- No new methods, imports, or other definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
