### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jonathanmagambo/otterlang/security/code-scanning/2](https://github.com/jonathanmagambo/otterlang/security/code-scanning/2)

The fix involves adding a `permissions` block to the workflow. Since there is only a single `test` job and no steps requiring token write access, the most restrictive and recommended configuration is to add `permissions: contents: read` at the top level, directly under the workflow name (and before `on:`). This ensures that the GITHUB_TOKEN available to the job has only read access to repository contents, minimizing risk. No other code or configuration changes are needed, and there are no new imports or dependencies required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
