### PR TITLE
add opt-in lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,77 @@ members = [
 
 [patch.crates-io]
 llvm-sys = { path = "vendor/llvm-sys" }
+
+# enable everything lint-wise, set priority to -1 for easy override
+[workspace.lints.clippy.pedantic]
+level = "warn"
+priority = -1
+
+[workspace.lints.clippy.nursery]
+level = "warn"
+priority = -1
+
+[workspace.lints.clippy.suspicious]
+level = "warn"
+priority = -1
+
+[workspace.lints.clippy.complexity]
+level = "warn"
+priority = -1
+
+[workspace.lints.clippy.perf]
+level = "warn"
+priority = -1
+
+[workspace.lints.clippy.restriction]
+level = "warn"
+priority = -1
+
+# allowlist
+[workspace.lints.clippy]
+
+# implicit_return is allowable because it is idiomatic
+implicit_return.level = "allow"
+
+# missing_trait_methods is allowable because otherwise it forces the
+# programmer to rewrite already written trait methods, which is
+# unnecessary and time-consuming
+missing_trait_methods.level = "allow"
+
+# float_arithmetic is allowable because we are not developing on platforms
+# that cannot support it
+float_arithmetic.level = "allow"
+
+# as_conversions is allowable because we already check all other as-
+# conversions, this lint activates regardless of if the proper checks
+# are in place
+as_conversions.level = "allow"
+
+# blanket_clippy_restriction_lints is allowable because we are actively
+# disabling restriction lints that are unnecessary
+blanket_clippy_restriction_lints.level = "allow"
+
+# separated_literal_suffix is allowable because it is purely stylistic
+separated_literal_suffix.level = "allow"
+
+# mod_module_files is allowable because it is stylistic
+mod_module_files.level = "allow"
+
+# wildcard_enum_match_arm is allowable because it disables the use of a
+# wildcard pattern, making code less concise and more unreadable
+wildcard_enum_match_arm.level = "allow"
+
+# pub_with_shorthand is allowable because rustfmt auto-formats certain
+# uses of pub without the shorthand to be shorthand.
+pub_with_shorthand.level = "allow"
+
+# pub_use is allowable because oftentimes you may re-export one, or multiple,
+# things, only restriction for this project is pub use with glob
+pub_use.level = "allow"
+
+# multiple_inherent_impl is allowable because we enforce that items - unless
+# explicitly said otherwise - must be sorted alphabetically; in our case, it
+# also makes sense that constructors are at the top of the impl-s for a type,
+# so it makes sense to separate - at least - constructors from the rest of the
+# impl-s.
+multiple_inherent_impl.level = "allow"


### PR DESCRIPTION
adds extremely pedantic lints (opt-in), they ensure a consistency across the code-base, and the goal is that in the future the code-base would be covered by them. More exceptions are expected to be added down the line, but should only be added with great consideration.