### PR TITLE
Implement Cranelift backend support and enhance code generation options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,8 +149,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
 dependencies = [
- "object",
+ "object 0.32.2",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "ariadne"
@@ -473,6 +479,161 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a41b85213deedf877555a7878ca9fb680ccba8183611c4bb8030ed281b2ad83"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce027a7b16f8b86f60ff6819615273635186d607a0c225ee6ac340d7d18f978"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a2d2ab65e6cbf91f81781d8da65ec2005510f18300eff21a99526ed6785863"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
+
+[[package]]
+name = "cranelift-control"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d70e5b75c2d5541ef80a99966ccd97aaa54d2a6af19ea31759a28538e1685a"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21d3089714278920030321829090d9482c91e5ff2339f2f697f8425bffdcba3"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7308482930f2a2fad4fe25a06054f6f9a4ee1ab97264308c661b037cb60001a3"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c59e259dab0e6958dabcc536b30845574f027ba6e5000498cdaf7e7ed2d30"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d4961d70f58f9f2fb89adfb847fe2a08b049f33dc5dd81d01b7e5ac46d40bf"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-jit-icache-coherence",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "215f383d347e0f170d32ce5e8d9eae6336279865a9418853c8946118c54bdb43"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77ac3dfb61ef3159998105116acdfeaec75e4296c43ee2dcc4ea39838c0080e"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-object"
+version = "0.110.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831bbb84d4ea2621195a836407686e0ba4083d47676eda470a01813e876b25eb"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-module",
+ "log",
+ "object 0.36.7",
+ "target-lexicon",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,10 +1063,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1317,6 +1504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1602,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1657,12 @@ dependencies = [
  "clap",
  "colored",
  "common",
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "cranelift-object",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1478,6 +1692,7 @@ dependencies = [
  "serde_yaml",
  "sha1",
  "sysinfo",
+ "target-lexicon",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1676,6 +1891,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1927,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "repr_offset"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1946,12 @@ checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
 dependencies = [
  "tstr",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1922,6 +2168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2279,12 @@ dependencies = [
  "rayon",
  "windows",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2415,6 +2673,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "23.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1a826e4ccd0803b2f7463289cad104f40d09d06bc8acf1a614230a47b4d96f"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/bin/lsp.rs"
 [features]
 default = []
 task-runtime = []
+cranelift-backend = []
 
 [dependencies]
 ast.path = "crates/ast"
@@ -58,6 +59,15 @@ inventory = "0.3"
 indicatif = "0.17"
 inkwell = { version = "0.x", features = ["llvm18-1"] }
 libloading = "0.8"
+
+# Cranelift backend dependencies
+cranelift-codegen = "0.110"
+cranelift-frontend = "0.110"
+cranelift-module = "0.110"
+cranelift-object = "0.110"
+cranelift-jit = "0.110"
+cranelift-native = "0.110"
+target-lexicon = "0.12"
 libm = "0.2"
 libc = "0.2"
 memmap2 = "0.9"
@@ -75,7 +85,7 @@ thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tower-lsp = "0.20"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "time"] }
 ratatui = "0.29.0"
 crossterm = "0.29.0"
 

--- a/examples/basic/task_benchmark.ot
+++ b/examples/basic/task_benchmark.ot
@@ -5,4 +5,3 @@ def sum_series(n: float) -> float:
 
 def main():
     let result = sum_series(100.0)
-nix d

--- a/src/codegen/cranelift.rs
+++ b/src/codegen/cranelift.rs
@@ -1,0 +1,2373 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+use cranelift_codegen::ir::InstBuilder;
+use cranelift_codegen::{Context, ir, isa, settings};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{DataId, FuncId, Linkage, Module};
+use cranelift_object::{ObjectBuilder, ObjectModule};
+use target_lexicon::Triple;
+use tracing::warn;
+
+use crate::codegen::llvm::{preferred_target_flag, prepare_rust_bridges};
+use crate::codegen::target::TargetTriple;
+use crate::codegen::{BuildArtifact, CodegenOptions};
+use crate::runtime::symbol_registry::SymbolRegistry;
+use crate::typecheck::TypeInfo;
+use ast::nodes::{
+    BinaryOp, Expr, FStringPart, Function, Literal, Program, Statement, Type, UnaryOp,
+};
+
+/// Build a native executable using the Cranelift backend
+pub fn build_executable(
+    program: &Program,
+    expr_types: &HashMap<usize, TypeInfo>,
+    output: &Path,
+    options: &CodegenOptions,
+) -> Result<BuildArtifact> {
+    let registry = crate::runtime::ffi::bootstrap_stdlib();
+    let bridge_libraries = prepare_rust_bridges(program, registry)?;
+
+    if options.emit_ir {
+        warn!(
+            "Cranelift backend does not currently support emitting textual IR; ignoring --dump-ir"
+        );
+    }
+    if options.enable_lto {
+        warn!("Cranelift backend does not support LTO; disabling -flto for this build");
+    }
+    if options.enable_pgo {
+        warn!("Cranelift backend does not support PGO; ignoring PGO-related flags");
+    }
+
+    // Ensure we have an entry point for executable builds
+    if !program.functions().any(|f| f.name == "main") {
+        bail!("entry function `main` not found");
+    }
+
+    let runtime_triple = resolve_runtime_triple(options);
+    let triple_str = runtime_triple.to_llvm_triple();
+
+    let mut backend =
+        CraneliftBackend::new(&runtime_triple, registry, clone_expr_type_map(expr_types))?;
+
+    let mut declared = Vec::new();
+    for function in program.functions() {
+        let func_id = backend.declare_function(function)?;
+        declared.push((func_id, function));
+    }
+    for (func_id, function) in declared {
+        backend.build_function(func_id, function)?;
+    }
+
+    let compiled = backend.finalize_module()?;
+    let object_bytes = compiled
+        .object_bytes
+        .ok_or_else(|| anyhow!("Cranelift backend did not produce object bytes"))?;
+
+    let object_path = output.with_extension("o");
+    fs::write(&object_path, &object_bytes).with_context(|| {
+        format!(
+            "failed to write Cranelift object file {}",
+            object_path.display()
+        )
+    })?;
+
+    let runtime_c = if runtime_triple.is_wasm() {
+        None
+    } else {
+        let runtime_c = output.with_extension("runtime.c");
+        let runtime_c_content = runtime_triple.runtime_c_code();
+        fs::write(&runtime_c, runtime_c_content)
+            .context("failed to write runtime C shim for Cranelift backend")?;
+        Some(runtime_c)
+    };
+
+    let runtime_o = if let Some(ref rt_c) = runtime_c {
+        let runtime_o = output.with_extension("runtime.o");
+        let c_compiler = runtime_triple.c_compiler();
+        let mut cc = Command::new(&c_compiler);
+        cc.arg("-c");
+        if runtime_triple.needs_pic() && !runtime_triple.is_windows() {
+            cc.arg("-fPIC");
+        }
+        let compiler_target_flag = preferred_target_flag(&c_compiler);
+        cc.arg(compiler_target_flag).arg(&triple_str);
+        cc.arg(rt_c).arg("-o").arg(&runtime_o);
+
+        let cc_status = cc
+            .status()
+            .context("failed to compile Cranelift runtime C shim")?;
+        if !cc_status.success() {
+            bail!("failed to compile runtime C shim for Cranelift backend");
+        }
+        Some(runtime_o)
+    } else {
+        None
+    };
+
+    let linker = runtime_triple.linker();
+    let mut cc = Command::new(&linker);
+    let linker_target_flag = preferred_target_flag(&linker);
+
+    if runtime_triple.is_wasm() {
+        cc.arg(linker_target_flag)
+            .arg(&triple_str)
+            .arg("--no-entry")
+            .arg("--export-dynamic")
+            .arg(&object_path)
+            .arg("-o")
+            .arg(output);
+    } else {
+        cc.arg(linker_target_flag).arg(&triple_str);
+        cc.arg(&object_path);
+        if let Some(ref rt_o) = runtime_o {
+            cc.arg(rt_o);
+        }
+        cc.arg("-o").arg(output);
+    }
+
+    for flag in runtime_triple.linker_flags() {
+        cc.arg(&flag);
+    }
+
+    for lib in &bridge_libraries {
+        cc.arg(lib);
+    }
+
+    let status = cc.status().context("failed to link Cranelift executable")?;
+
+    if !status.success() {
+        bail!("linker invocation failed with status {status}");
+    }
+
+    if let Some(ref rt_c) = runtime_c {
+        fs::remove_file(rt_c).ok();
+    }
+    if let Some(ref rt_o) = runtime_o {
+        fs::remove_file(rt_o).ok();
+    }
+    fs::remove_file(&object_path).ok();
+
+    Ok(BuildArtifact {
+        binary: output.to_path_buf(),
+        ir: None,
+    })
+}
+
+/// Build a shared library using the Cranelift backend
+pub fn build_shared_library(
+    program: &Program,
+    expr_types: &HashMap<usize, TypeInfo>,
+    output: &Path,
+    options: &CodegenOptions,
+) -> Result<BuildArtifact> {
+    let registry = crate::runtime::ffi::bootstrap_stdlib();
+    let bridge_libraries = prepare_rust_bridges(program, registry)?;
+
+    if options.emit_ir {
+        warn!(
+            "Cranelift backend does not currently support emitting textual IR; ignoring --dump-ir"
+        );
+    }
+    if options.enable_lto {
+        warn!("Cranelift backend does not support LTO; disabling -flto for this build");
+    }
+    if options.enable_pgo {
+        warn!("Cranelift backend does not support PGO; ignoring PGO-related flags");
+    }
+
+    let runtime_triple = resolve_runtime_triple(options);
+    let triple_str = runtime_triple.to_llvm_triple();
+
+    let mut backend =
+        CraneliftBackend::new(&runtime_triple, registry, clone_expr_type_map(expr_types))?;
+
+    // Two-pass lowering: declare all functions before defining bodies
+    let mut declared = Vec::new();
+    for function in program.functions() {
+        let func_id = backend.declare_function(function)?;
+        declared.push((func_id, function));
+    }
+    for (func_id, function) in declared {
+        backend.build_function(func_id, function)?;
+    }
+
+    let compiled = backend.finalize_module()?;
+    let object_bytes = compiled
+        .object_bytes
+        .ok_or_else(|| anyhow!("Cranelift backend did not produce object bytes"))?;
+
+    let object_path = output.with_extension("o");
+    fs::write(&object_path, &object_bytes).with_context(|| {
+        format!(
+            "failed to write Cranelift object file {}",
+            object_path.display()
+        )
+    })?;
+
+    let runtime_c = if runtime_triple.is_wasm() {
+        None
+    } else {
+        let runtime_c = output.with_extension("runtime.c");
+        let runtime_c_content = runtime_triple.runtime_c_code();
+        fs::write(&runtime_c, runtime_c_content)
+            .context("failed to write runtime C shim for Cranelift backend")?;
+        Some(runtime_c)
+    };
+
+    let runtime_o = if let Some(ref rt_c) = runtime_c {
+        let runtime_o = output.with_extension("runtime.o");
+        let c_compiler = runtime_triple.c_compiler();
+        let mut cc = Command::new(&c_compiler);
+        cc.arg("-c");
+        if runtime_triple.needs_pic() && !runtime_triple.is_windows() {
+            cc.arg("-fPIC");
+        }
+        let compiler_target_flag = preferred_target_flag(&c_compiler);
+        cc.arg(compiler_target_flag).arg(&triple_str);
+        cc.arg(rt_c).arg("-o").arg(&runtime_o);
+
+        let cc_status = cc
+            .status()
+            .context("failed to compile Cranelift runtime C shim")?;
+        if !cc_status.success() {
+            bail!("failed to compile runtime C shim for Cranelift backend");
+        }
+        Some(runtime_o)
+    } else {
+        None
+    };
+
+    let lib_ext = if runtime_triple.is_wasm() {
+        "wasm"
+    } else if runtime_triple.is_windows() {
+        "dll"
+    } else if runtime_triple.os == "darwin" {
+        "dylib"
+    } else {
+        "so"
+    };
+    let lib_path = if output
+        .extension()
+        .map(|ext| ext == lib_ext)
+        .unwrap_or(false)
+    {
+        output.to_path_buf()
+    } else {
+        output.with_extension(lib_ext)
+    };
+
+    let linker = runtime_triple.linker();
+    let mut cc = Command::new(&linker);
+    let linker_target_flag = preferred_target_flag(&linker);
+
+    if runtime_triple.is_wasm() {
+        cc.arg(linker_target_flag)
+            .arg(&triple_str)
+            .arg("--no-entry")
+            .arg("--export-dynamic")
+            .arg("-o")
+            .arg(&lib_path)
+            .arg(&object_path);
+    } else {
+        cc.arg("-shared");
+        if runtime_triple.needs_pic() {
+            cc.arg("-fPIC");
+        }
+        cc.arg(linker_target_flag).arg(&triple_str);
+        cc.arg("-o").arg(&lib_path).arg(&object_path);
+        if let Some(ref rt_o) = runtime_o {
+            cc.arg(rt_o);
+        }
+    }
+
+    for flag in runtime_triple.linker_flags() {
+        cc.arg(&flag);
+    }
+
+    for lib in &bridge_libraries {
+        cc.arg(lib);
+    }
+
+    let status = cc
+        .status()
+        .context("failed to invoke system linker for Cranelift backend")?;
+    if !status.success() {
+        bail!("Cranelift linker invocation failed with status {status}");
+    }
+
+    if let Some(ref rt_c) = runtime_c {
+        fs::remove_file(rt_c).ok();
+    }
+    if let Some(ref rt_o) = runtime_o {
+        fs::remove_file(rt_o).ok();
+    }
+    fs::remove_file(&object_path).ok();
+
+    Ok(BuildArtifact {
+        binary: lib_path,
+        ir: None,
+    })
+}
+
+fn resolve_runtime_triple(options: &CodegenOptions) -> TargetTriple {
+    if let Some(ref target) = options.target {
+        return target.clone();
+    }
+
+    let native = target_lexicon::Triple::host();
+    let native_str = native.to_string();
+    TargetTriple::parse(&native_str)
+        .unwrap_or_else(|_| TargetTriple::new("x86_64", "unknown", "linux", Some("gnu")))
+}
+
+fn clone_expr_type_map(expr_types: &HashMap<usize, TypeInfo>) -> HashMap<usize, TypeInfo> {
+    expr_types
+        .iter()
+        .map(|(id, ty)| (*id, ty.clone()))
+        .collect::<HashMap<_, _>>()
+}
+
+/// Backend-agnostic codegen trait
+pub trait CodegenBackend {
+    /// Declare a function with the given signature
+    fn declare_function(&mut self, function: &Function) -> Result<FuncId>;
+
+    /// Build the body of a declared function
+    fn build_function(&mut self, func_id: FuncId, function: &Function) -> Result<()>;
+
+    /// Finalize the module and return compiled artifacts
+    fn finalize_module(&mut self) -> Result<CompiledModule>;
+
+    /// Get information about the target platform
+    fn get_target_info(&self) -> TargetInfo;
+
+    /// Emit an object file to the given path
+    fn emit_object_file(&self, path: &Path) -> Result<()>;
+
+    /// Create a JIT context for runtime execution
+    fn create_jit_context(&self) -> Result<JitContext>;
+}
+
+/// Information about the compilation target
+#[derive(Debug, Clone)]
+pub struct TargetInfo {
+    pub triple: Triple,
+    pub pointer_width: u32,
+    pub endianness: target_lexicon::Endianness,
+}
+
+/// Compiled module containing functions and data
+#[derive(Debug)]
+pub struct CompiledModule {
+    pub functions: HashMap<String, FuncId>,
+    pub data_objects: HashMap<String, DataId>,
+    pub object_bytes: Option<Vec<u8>>,
+}
+
+/// JIT context for runtime execution
+#[derive(Debug)]
+pub struct JitContext {
+    /// The JIT module for dynamic code execution
+    pub module: JITModule,
+    /// Cache of declared functions in the JIT module
+    pub functions: HashMap<String, FuncId>,
+}
+
+/// Cranelift-based codegen backend
+pub struct CraneliftBackend {
+    /// The Cranelift module for managing functions and data
+    module: ObjectModule,
+    /// Function builder context for reusing allocations
+    fn_builder_ctx: FunctionBuilderContext,
+    /// Target ISA for code generation
+    isa: std::sync::Arc<dyn isa::TargetIsa>,
+    /// Symbol registry for FFI functions
+    _symbol_registry: &'static SymbolRegistry,
+    /// Type information from type checking
+    _expr_types: HashMap<usize, TypeInfo>,
+    /// Cache of declared functions
+    declared_functions: HashMap<String, FuncId>,
+    /// Cache of declared data objects
+    declared_data: HashMap<String, DataId>,
+}
+
+impl CraneliftBackend {
+    /// Create a new Cranelift backend with the given configuration
+    pub fn new(
+        target: &TargetTriple,
+        symbol_registry: &'static SymbolRegistry,
+        expr_types: HashMap<usize, TypeInfo>,
+    ) -> Result<Self> {
+        // Convert our TargetTriple to target-lexicon Triple
+        let triple = Self::target_triple_to_lexicon(target)?;
+
+        // Create ISA builder for the target
+        let isa = isa::lookup(triple.clone())
+            .map_err(|e| anyhow!("Failed to create ISA for target {}: {}", triple, e))?
+            .finish(settings::Flags::new(settings::builder()))
+            .map_err(|e| anyhow!("Failed to finish ISA setup: {}", e))?;
+
+        // Create object module
+        let module = ObjectModule::new(
+            ObjectBuilder::new(
+                isa.clone(),
+                "otterlang".to_string(),
+                cranelift_module::default_libcall_names(),
+            )
+            .map_err(|e| anyhow!("Failed to create object builder: {}", e))?,
+        );
+
+        Ok(Self {
+            module,
+            fn_builder_ctx: FunctionBuilderContext::new(),
+            isa,
+            _symbol_registry: symbol_registry,
+            _expr_types: expr_types,
+            declared_functions: HashMap::new(),
+            declared_data: HashMap::new(),
+        })
+    }
+
+    /// Convert our TargetTriple to target-lexicon Triple
+    fn target_triple_to_lexicon(target: &TargetTriple) -> Result<Triple> {
+        let triple_str = format!("{}-{}-{}", target.arch, target.vendor, target.os);
+        triple_str
+            .parse()
+            .map_err(|e| anyhow!("Invalid target triple {}: {}", triple_str, e))
+    }
+
+    /// Convert Otter TypeInfo to Cranelift type
+    fn type_info_to_cranelift(&self, type_info: &TypeInfo) -> Result<ir::Type> {
+        match type_info {
+            TypeInfo::Unit => Ok(ir::types::INVALID), // Void/unit type
+            TypeInfo::Bool => Ok(ir::types::I8),
+            TypeInfo::I32 => Ok(ir::types::I32),
+            TypeInfo::I64 => Ok(ir::types::I64),
+            TypeInfo::F64 => Ok(ir::types::F64),
+            TypeInfo::Str => Ok(self.module.target_config().pointer_type()), // String as pointer
+            TypeInfo::List(_) | TypeInfo::Dict { .. } => {
+                // Collections are represented as pointers for now
+                Ok(self.module.target_config().pointer_type())
+            }
+            TypeInfo::Function { .. } => {
+                // Function pointers
+                Ok(self.module.target_config().pointer_type())
+            }
+            TypeInfo::Struct { .. } | TypeInfo::Enum { .. } => {
+                // Custom types are represented as pointers
+                // In a full implementation, we might want to handle structs differently
+                Ok(self.module.target_config().pointer_type())
+            }
+            TypeInfo::Generic { base, args } => {
+                // Handle generic types based on base type
+                match base.as_str() {
+                    "List" | "list" => Ok(self.module.target_config().pointer_type()),
+                    "Dict" | "dict" | "Map" | "map" => {
+                        Ok(self.module.target_config().pointer_type())
+                    }
+                    _ => {
+                        // For custom generic types, use pointer representation
+                        Ok(self.module.target_config().pointer_type())
+                    }
+                }
+            }
+            TypeInfo::Alias { underlying, .. } => {
+                // Follow the alias to the underlying type
+                self.type_info_to_cranelift(underlying)
+            }
+            TypeInfo::Unknown => {
+                // Unknown types default to pointer size
+                Ok(self.module.target_config().pointer_type())
+            }
+            TypeInfo::Error => {
+                // Error types are represented as strings
+                Ok(self.module.target_config().pointer_type())
+            }
+            TypeInfo::Module(_) => {
+                // Module types are opaque pointers
+                Ok(self.module.target_config().pointer_type())
+            }
+        }
+    }
+
+    /// Convert Otter AST Type to Cranelift type (legacy method for backward compatibility)
+    fn otter_type_to_cranelift(&self, otter_type: &Type) -> Result<ir::Type> {
+        // Convert AST Type to TypeInfo first, then to Cranelift type
+        let type_info = TypeInfo::from(otter_type);
+        self.type_info_to_cranelift(&type_info)
+    }
+
+    /// Build a function signature from Otter function
+    fn build_signature(&self, function: &Function) -> Result<ir::Signature> {
+        let mut sig = ir::Signature::new(self.isa.default_call_conv());
+
+        // Add parameters
+        for param in &function.params {
+            if let Some(ty) = &param.ty {
+                let param_type = self.otter_type_to_cranelift(ty)?;
+                sig.params.push(ir::AbiParam::new(param_type));
+            } else {
+                // Default to i64 if no type specified
+                sig.params.push(ir::AbiParam::new(ir::types::I64));
+            }
+        }
+
+        // Add return type
+        let ret_type = if let Some(ret_ty) = &function.ret_ty {
+            self.otter_type_to_cranelift(ret_ty)?
+        } else {
+            ir::types::I64 // Default return type
+        };
+
+        if ret_type != ir::types::INVALID {
+            sig.returns.push(ir::AbiParam::new(ret_type));
+        }
+
+        Ok(sig)
+    }
+
+    /// Lower a block of statements to Cranelift IR
+    fn lower_block_with_builder(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        block: &ast::nodes::Block,
+        variables: &mut HashMap<String, ir::Value>,
+    ) -> Result<ir::Value> {
+        let mut last_value = None;
+
+        for stmt in &block.statements {
+            match stmt {
+                Statement::Let { name, expr, .. } => {
+                    let val = self.lower_expr_with_builder(builder, expr, variables)?;
+                    variables.insert(name.clone(), val);
+                    last_value = Some(val);
+                }
+                Statement::Return(expr) => {
+                    if let Some(expr) = expr {
+                        let val = self.lower_expr_with_builder(builder, expr, variables)?;
+                        builder.ins().return_(&[val]);
+                    } else {
+                        // Return void
+                        builder.ins().return_(&[]);
+                    }
+                    // For simplicity, return a dummy value after return statement
+                    // In a full implementation, we'd need to handle control flow properly
+                    last_value = Some(builder.ins().iconst(ir::types::I64, 0));
+                }
+                Statement::Function(_) => {
+                    // Function declarations are handled at module level
+                    // Skip here
+                }
+                _ => bail!("Statement type not yet implemented: {:?}", stmt),
+            }
+        }
+
+        // Return the last computed value, or a default if no statements
+        Ok(last_value.unwrap_or_else(|| builder.ins().iconst(ir::types::I64, 0)))
+    }
+
+    /// Lower an expression to Cranelift IR
+    fn lower_expr_with_builder(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        expr: &Expr,
+        variables: &HashMap<String, ir::Value>,
+    ) -> Result<ir::Value> {
+        match expr {
+            Expr::Literal(lit) => self.lower_literal_with_builder(builder, lit),
+            Expr::Identifier { name, .. } => variables
+                .get(name)
+                .copied()
+                .ok_or_else(|| anyhow!("Undefined variable: {}", name)),
+            Expr::Binary { left, op, right } => {
+                let left_val = self.lower_expr_with_builder(builder, left, variables)?;
+                let right_val = self.lower_expr_with_builder(builder, right, variables)?;
+                Self::lower_binary_op_with_builder(builder, *op, left_val, right_val)
+            }
+            Expr::Call { func, args } => {
+                self.lower_call_with_builder(builder, func, args, variables)
+            }
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.lower_if_expr_with_builder(builder, cond, then_branch, else_branch, variables)
+            }
+            Expr::Unary { op, expr } => {
+                let val = self.lower_expr_with_builder(builder, expr, variables)?;
+                Self::lower_unary_op_with_builder(builder, *op, val)
+            }
+            Expr::Member { object, field } => {
+                let object_val = self.lower_expr_with_builder(builder, object, variables)?;
+
+                // For member access, we assume the object is a pointer to a struct
+                // and we need to calculate the field offset.
+                // In a real implementation, this would look up the struct definition
+                // and calculate proper field offsets based on the struct layout.
+
+                // For now, use a simple approach: assume fields are at fixed offsets
+                // This is highly simplified and would need proper struct layout knowledge
+
+                // Calculate field offset (simplified: assume each field is pointer-sized)
+                let field_offset = match field.as_str() {
+                    // Common field names get predefined offsets
+                    "x" | "0" => 0,  // First field
+                    "y" | "1" => 8,  // Second field (assuming 64-bit pointers)
+                    "z" | "2" => 16, // Third field
+                    _ => {
+                        // For unknown fields, use a hash-based offset (not ideal but deterministic)
+                        use std::collections::hash_map::DefaultHasher;
+                        use std::hash::{Hash, Hasher};
+                        let mut hasher = DefaultHasher::new();
+                        field.hash(&mut hasher);
+                        (hasher.finish() % 100 * 8) as i32 // Limit to reasonable offset
+                    }
+                };
+
+                // Calculate address of field: object_ptr + offset
+                let offset_val = builder.ins().iconst(ir::types::I64, field_offset as i64);
+                let field_addr = builder.ins().iadd(object_val, offset_val);
+
+                // Load the field value (assume it's a pointer-sized value)
+                let field_value =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), field_addr, 0);
+
+                Ok(field_value)
+            }
+            Expr::Array(elements) => {
+                if elements.is_empty() {
+                    // Empty array - return null pointer for now
+                    Ok(builder.ins().iconst(ir::types::I64, 0))
+                } else {
+                    // Allocate memory for the array
+                    let num_elements = elements.len();
+                    let element_size = 8; // Assume pointer-sized elements for now
+                    let total_size = num_elements * element_size;
+
+                    // Call external allocation function
+                    let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+                        id
+                    } else {
+                        // Declare malloc: fn(size: usize) -> *mut u8
+                        let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                        sig.params.push(ir::AbiParam::new(ir::types::I64)); // size parameter
+                        sig.returns.push(ir::AbiParam::new(
+                            self.module.target_config().pointer_type(),
+                        ));
+
+                        let func_id = self
+                            .module
+                            .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                            .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+
+                        self.declared_functions
+                            .insert("malloc".to_string(), func_id);
+                        func_id
+                    };
+
+                    // Allocate memory
+                    let size_val = builder.ins().iconst(ir::types::I64, total_size as i64);
+                    let malloc_call = self
+                        .module
+                        .declare_func_in_func(malloc_func_id, builder.func);
+                    let array_ptr = builder.ins().call(malloc_call, &[size_val]);
+
+                    // Initialize array elements
+                    for (i, element) in elements.iter().enumerate() {
+                        let element_val =
+                            self.lower_expr_with_builder(builder, element, variables)?;
+
+                        // Calculate offset for this element
+                        let offset = (i * element_size) as i32;
+                        let element_addr = builder.ins().iadd(
+                            array_ptr,
+                            builder.ins().iconst(ir::types::I64, offset as i64),
+                        );
+
+                        // Store element value
+                        builder
+                            .ins()
+                            .store(ir::MemFlags::new(), element_val, element_addr, 0);
+                    }
+
+                    Ok(array_ptr)
+                }
+            }
+            Expr::Dict(pairs) => {
+                if pairs.is_empty() {
+                    // Empty dict - return null pointer for now
+                    Ok(builder.ins().iconst(ir::types::I64, 0))
+                } else {
+                    // Allocate memory for the dictionary
+                    // Structure: [key1, value1, key2, value2, ...]
+                    let num_pairs = pairs.len();
+                    let entry_size = 16; // key + value (both pointer-sized)
+                    let total_size = num_pairs * entry_size;
+
+                    // Call external allocation function
+                    let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+                        id
+                    } else {
+                        // Declare malloc: fn(size: usize) -> *mut u8
+                        let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                        sig.params.push(ir::AbiParam::new(ir::types::I64)); // size parameter
+                        sig.returns.push(ir::AbiParam::new(
+                            self.module.target_config().pointer_type(),
+                        ));
+
+                        let func_id = self
+                            .module
+                            .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                            .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+
+                        self.declared_functions
+                            .insert("malloc".to_string(), func_id);
+                        func_id
+                    };
+
+                    // Allocate memory
+                    let size_val = builder.ins().iconst(ir::types::I64, total_size as i64);
+                    let malloc_call = self
+                        .module
+                        .declare_func_in_func(malloc_func_id, builder.func);
+                    let dict_ptr = builder.ins().call(malloc_call, &[size_val]);
+
+                    // Initialize dictionary entries
+                    for (i, (key_expr, value_expr)) in pairs.iter().enumerate() {
+                        let key_val = self.lower_expr_with_builder(builder, key_expr, variables)?;
+                        let value_val =
+                            self.lower_expr_with_builder(builder, value_expr, variables)?;
+
+                        // Calculate offsets for key and value in this entry
+                        let entry_offset = i * entry_size;
+                        let key_offset = entry_offset;
+                        let value_offset = entry_offset + 8;
+
+                        // Store key
+                        let key_addr = builder.ins().iadd(
+                            dict_ptr,
+                            builder.ins().iconst(ir::types::I64, key_offset as i64),
+                        );
+                        builder
+                            .ins()
+                            .store(ir::MemFlags::new(), key_val, key_addr, 0);
+
+                        // Store value
+                        let value_addr = builder.ins().iadd(
+                            dict_ptr,
+                            builder.ins().iconst(ir::types::I64, value_offset as i64),
+                        );
+                        builder
+                            .ins()
+                            .store(ir::MemFlags::new(), value_val, value_addr, 0);
+                    }
+
+                    Ok(dict_ptr)
+                }
+            }
+            Expr::Struct { name: _, fields } => {
+                // Allocate memory for the struct
+                let num_fields = fields.len();
+                if num_fields == 0 {
+                    // Empty struct - return null pointer
+                    Ok(builder.ins().iconst(ir::types::I64, 0))
+                } else {
+                    let field_size = 8; // Assume pointer-sized fields for now
+                    let total_size = num_fields * field_size;
+
+                    // Call external allocation function
+                    let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+                        id
+                    } else {
+                        // Declare malloc: fn(size: usize) -> *mut u8
+                        let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                        sig.params.push(ir::AbiParam::new(ir::types::I64)); // size parameter
+                        sig.returns.push(ir::AbiParam::new(
+                            self.module.target_config().pointer_type(),
+                        ));
+
+                        let func_id = self
+                            .module
+                            .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                            .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+
+                        self.declared_functions
+                            .insert("malloc".to_string(), func_id);
+                        func_id
+                    };
+
+                    // Allocate memory
+                    let size_val = builder.ins().iconst(ir::types::I64, total_size as i64);
+                    let malloc_call = self
+                        .module
+                        .declare_func_in_func(malloc_func_id, builder.func);
+                    let struct_ptr = builder.ins().call(malloc_call, &[size_val]);
+
+                    // Initialize struct fields
+                    for (i, (field_name, field_expr)) in fields.iter().enumerate() {
+                        let field_val =
+                            self.lower_expr_with_builder(builder, field_expr, variables)?;
+
+                        // Calculate field offset (use same logic as member access)
+                        let field_offset = match field_name.as_str() {
+                            "x" | "0" => 0,
+                            "y" | "1" => 8,
+                            "z" | "2" => 16,
+                            _ => {
+                                // For unknown fields, use index-based offset
+                                i * field_size
+                            }
+                        };
+
+                        // Store field value
+                        let field_addr = builder.ins().iadd(
+                            struct_ptr,
+                            builder.ins().iconst(ir::types::I64, field_offset as i64),
+                        );
+                        builder
+                            .ins()
+                            .store(ir::MemFlags::new(), field_val, field_addr, 0);
+                    }
+
+                    Ok(struct_ptr)
+                }
+            }
+            Expr::Match { value, arms } => {
+                // Evaluate the value to match against
+                let match_value = self.lower_expr_with_builder(builder, value, variables)?;
+
+                // Create blocks for each arm and a default block
+                let mut arm_blocks = Vec::new();
+                let mut arm_end_blocks = Vec::new();
+                let merge_block = builder.create_block();
+                let result_type = ir::types::I64; // Assume all match arms return the same type
+                builder.append_block_param(merge_block, result_type);
+
+                for _ in arms {
+                    arm_blocks.push(builder.create_block());
+                    arm_end_blocks.push(builder.create_block());
+                }
+
+                // Create a default block for when no pattern matches
+                let default_block = builder.create_block();
+                let default_val = builder.ins().iconst(ir::types::I64, 0); // Default value when no match
+                builder.switch_to_block(default_block);
+                builder.ins().jump(merge_block, &[default_val]);
+
+                // Process each arm
+                for (i, arm) in arms.iter().enumerate() {
+                    builder.switch_to_block(arm_blocks[i]);
+
+                    // Check if pattern matches
+                    let pattern_matches =
+                        self.lower_pattern_match(builder, &arm.pattern, match_value, variables)?;
+
+                    // If there's a guard, also check it
+                    let guard_passes = if let Some(guard) = &arm.guard {
+                        let guard_val = self.lower_expr_with_builder(builder, guard, variables)?;
+                        // Convert to boolean (non-zero = true)
+                        let zero = builder.ins().iconst(ir::types::I8, 0);
+                        builder
+                            .ins()
+                            .icmp(ir::condcodes::IntCC::NotEqual, guard_val, zero)
+                    } else {
+                        // No guard, always true
+                        builder.ins().iconst(ir::types::I8, 1)
+                    };
+
+                    // Both pattern and guard must pass
+                    let condition = builder.ins().band(pattern_matches, guard_passes);
+
+                    // If condition is true, execute body; else try next arm or default
+                    let next_block = if i + 1 < arms.len() {
+                        arm_blocks[i + 1]
+                    } else {
+                        default_block
+                    };
+
+                    builder
+                        .ins()
+                        .brif(condition, arm_end_blocks[i], &[], next_block, &[]);
+
+                    // Execute the arm body
+                    builder.switch_to_block(arm_end_blocks[i]);
+                    let arm_result = self.lower_expr_with_builder(builder, &arm.body, variables)?;
+                    builder.ins().jump(merge_block, &[arm_result]);
+                }
+
+                // Start with the first arm
+                if !arms.is_empty() {
+                    builder.switch_to_block(arm_blocks[0]);
+                    builder.ins().jump(arm_blocks[0], &[]);
+                }
+
+                // Seal all blocks
+                for block in &arm_blocks {
+                    builder.seal_block(*block);
+                }
+                for block in &arm_end_blocks {
+                    builder.seal_block(*block);
+                }
+                builder.seal_block(default_block);
+                builder.seal_block(merge_block);
+
+                // Return the result
+                builder.switch_to_block(merge_block);
+                let result = builder.block_params(merge_block)[0];
+                Ok(result)
+            }
+            Expr::Range { start, end } => {
+                // Create a range object with start and end values
+                // Structure: [start, end] (two pointer-sized values)
+
+                let start_val = self.lower_expr_with_builder(builder, start, variables)?;
+                let end_val = self.lower_expr_with_builder(builder, end, variables)?;
+
+                // Allocate memory for range struct (start + end)
+                let range_size = 16; // Two pointer-sized values
+
+                // Call external allocation function
+                let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+                    id
+                } else {
+                    // Declare malloc: fn(size: usize) -> *mut u8
+                    let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                    sig.params.push(ir::AbiParam::new(ir::types::I64)); // size parameter
+                    sig.returns.push(ir::AbiParam::new(
+                        self.module.target_config().pointer_type(),
+                    ));
+
+                    let func_id = self
+                        .module
+                        .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                        .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+
+                    self.declared_functions
+                        .insert("malloc".to_string(), func_id);
+                    func_id
+                };
+
+                // Allocate memory
+                let size_val = builder.ins().iconst(ir::types::I64, range_size);
+                let malloc_call = self
+                    .module
+                    .declare_func_in_func(malloc_func_id, builder.func);
+                let range_ptr = builder.ins().call(malloc_call, &[size_val]);
+
+                // Store start value at offset 0
+                let start_addr = range_ptr;
+                builder
+                    .ins()
+                    .store(ir::MemFlags::new(), start_val, start_addr, 0);
+
+                // Store end value at offset 8
+                let end_addr = builder
+                    .ins()
+                    .iadd(range_ptr, builder.ins().iconst(ir::types::I64, 8));
+                builder
+                    .ins()
+                    .store(ir::MemFlags::new(), end_val, end_addr, 0);
+
+                Ok(range_ptr)
+            }
+            Expr::ListComprehension {
+                element,
+                var,
+                iterable,
+                condition,
+            } => {
+                // Implement proper list comprehension with iteration
+                // This handles array iteration with dynamic result collection
+
+                // Evaluate the iterable (assume it's an array for now)
+                let iterable_val = self.lower_expr_with_builder(builder, iterable, variables)?;
+
+                // Create loop structure for iteration
+                let loop_header = builder.create_block();
+                let loop_body = builder.create_block();
+                let loop_exit = builder.create_block();
+                let result_merge = builder.create_block();
+                builder
+                    .append_block_param(result_merge, self.module.target_config().pointer_type());
+
+                // Initialize loop variables
+                let index_var = builder.ins().iconst(ir::types::I64, 0); // Current index
+                let result_ptr_var = builder.ins().iconst(ir::types::I64, 0); // Result array (initially null)
+                let result_count_var = builder.ins().iconst(ir::types::I64, 0); // Number of elements added
+
+                // Jump to loop header
+                builder
+                    .ins()
+                    .jump(loop_header, &[index_var, result_ptr_var, result_count_var]);
+
+                // Loop header: check if we've reached the end
+                builder.switch_to_block(loop_header);
+                let current_index = builder.block_params(loop_header)[0];
+                let current_result_ptr = builder.block_params(loop_header)[1];
+                let current_result_count = builder.block_params(loop_header)[2];
+
+                // Read the array length from the first element of the array structure
+                let length_addr = iterable_val; // Length is at offset 0
+                let array_length =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), length_addr, 0);
+
+                let continue_loop = builder.ins().icmp(
+                    ir::condcodes::IntCC::SignedLessThan,
+                    current_index,
+                    array_length,
+                );
+                builder.ins().brif(
+                    continue_loop,
+                    loop_body,
+                    &[],
+                    loop_exit,
+                    &[current_result_ptr],
+                );
+
+                // Loop body: process each element
+                builder.switch_to_block(loop_body);
+
+                // Load current element from iterable array
+                // Array structure: [length, element0, element1, ...] so elements start at offset 8
+                let element_offset = builder.ins().iadd(
+                    builder.ins().iconst(ir::types::I64, 8), // Skip length field
+                    builder
+                        .ins()
+                        .imul(current_index, builder.ins().iconst(ir::types::I64, 8)),
+                );
+                let element_addr = builder.ins().iadd(iterable_val, element_offset);
+                let current_element =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), element_addr, 0);
+
+                // Bind the element to the variable
+                variables.insert(var.clone(), current_element);
+
+                // Check condition if present
+                let condition_met = if let Some(cond) = condition {
+                    let cond_val = self.lower_expr_with_builder(builder, cond, variables)?;
+                    // Convert to boolean (non-zero means true)
+                    builder.ins().icmp(
+                        ir::condcodes::IntCC::NotEqual,
+                        cond_val,
+                        builder.ins().iconst(ir::types::I64, 0),
+                    )
+                } else {
+                    builder.ins().iconst(ir::types::I8, 1) // No condition, always true
+                };
+
+                // Create blocks for conditional element addition
+                let add_element_block = builder.create_block();
+                let skip_element_block = builder.create_block();
+                let element_merge_block = builder.create_block();
+                builder.append_block_param(
+                    element_merge_block,
+                    self.module.target_config().pointer_type(),
+                );
+                builder.append_block_param(element_merge_block, ir::types::I64);
+
+                builder.ins().brif(
+                    condition_met,
+                    add_element_block,
+                    &[],
+                    skip_element_block,
+                    &[],
+                );
+
+                // Add element block: evaluate element expression and add to result
+                builder.switch_to_block(add_element_block);
+                let elem_val = self.lower_expr_with_builder(builder, element, variables)?;
+
+                // Grow result array or create new one
+                let (new_result_ptr, new_result_count) = self.grow_result_array(
+                    builder,
+                    current_result_ptr,
+                    current_result_count,
+                    elem_val,
+                )?;
+
+                builder
+                    .ins()
+                    .jump(element_merge_block, &[new_result_ptr, new_result_count]);
+
+                // Skip element block: keep current result
+                builder.switch_to_block(skip_element_block);
+                builder.ins().jump(
+                    element_merge_block,
+                    &[current_result_ptr, current_result_count],
+                );
+
+                // Element merge: continue loop with updated result
+                builder.switch_to_block(element_merge_block);
+                let updated_result_ptr = builder.block_params(element_merge_block)[0];
+                let updated_result_count = builder.block_params(element_merge_block)[1];
+
+                let next_index = builder
+                    .ins()
+                    .iadd(current_index, builder.ins().iconst(ir::types::I64, 1));
+                builder.ins().jump(
+                    loop_header,
+                    &[next_index, updated_result_ptr, updated_result_count],
+                );
+
+                // Loop exit: return final result
+                builder.switch_to_block(loop_exit);
+                let final_result = builder.block_params(loop_exit)[0];
+                builder.ins().jump(result_merge, &[final_result]);
+
+                // Result merge and return
+                builder.switch_to_block(result_merge);
+                let result = builder.block_params(result_merge)[0];
+
+                // Seal all blocks
+                builder.seal_block(loop_header);
+                builder.seal_block(loop_body);
+                builder.seal_block(loop_exit);
+                builder.seal_block(add_element_block);
+                builder.seal_block(skip_element_block);
+                builder.seal_block(element_merge_block);
+                builder.seal_block(result_merge);
+
+                Ok(result)
+            }
+            Expr::DictComprehension {
+                key,
+                value,
+                var,
+                iterable,
+                condition,
+            } => {
+                // Lower dict comprehensions using a loop similar to list comprehensions.
+                let iterable_val = self.lower_expr_with_builder(builder, iterable, variables)?;
+
+                // Create loop structure
+                let loop_header = builder.create_block();
+                let loop_body = builder.create_block();
+                let loop_exit = builder.create_block();
+                let result_merge = builder.create_block();
+                let pointer_type = self.module.target_config().pointer_type();
+
+                builder.append_block_param(loop_header, ir::types::I64); // index
+                builder.append_block_param(loop_header, pointer_type); // dict pointer
+                builder.append_block_param(loop_header, ir::types::I64); // entry count
+                builder.append_block_param(result_merge, pointer_type);
+
+                // Initialize loop state
+                let start_index = builder.ins().iconst(ir::types::I64, 0);
+                let start_dict = builder.ins().iconst(pointer_type, 0);
+                let start_count = builder.ins().iconst(ir::types::I64, 0);
+                builder
+                    .ins()
+                    .jump(loop_header, &[start_index, start_dict, start_count]);
+
+                // Loop header
+                builder.switch_to_block(loop_header);
+                let current_index = builder.block_params(loop_header)[0];
+                let current_dict_ptr = builder.block_params(loop_header)[1];
+                let current_count = builder.block_params(loop_header)[2];
+
+                // Assume iterable arrays store length at offset 0.
+                let length_addr = iterable_val;
+                let array_length =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), length_addr, 0);
+                let continue_loop = builder.ins().icmp(
+                    ir::condcodes::IntCC::SignedLessThan,
+                    current_index,
+                    array_length,
+                );
+                builder.ins().brif(
+                    continue_loop,
+                    loop_body,
+                    &[],
+                    loop_exit,
+                    &[current_dict_ptr],
+                );
+
+                // Loop body
+                builder.switch_to_block(loop_body);
+
+                // Load iterable element (offset 8 + index * 8)
+                let element_offset = builder.ins().iadd(
+                    builder.ins().iconst(ir::types::I64, 8),
+                    builder
+                        .ins()
+                        .imul(current_index, builder.ins().iconst(ir::types::I64, 8)),
+                );
+                let element_addr = builder.ins().iadd(iterable_val, element_offset);
+                let current_element =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), element_addr, 0);
+                variables.insert(var.clone(), current_element);
+
+                // Evaluate optional condition
+                let condition_met = if let Some(cond) = condition {
+                    let cond_val = self.lower_expr_with_builder(builder, cond, variables)?;
+                    builder.ins().icmp(
+                        ir::condcodes::IntCC::NotEqual,
+                        cond_val,
+                        builder.ins().iconst(ir::types::I64, 0),
+                    )
+                } else {
+                    builder.ins().iconst(ir::types::I8, 1)
+                };
+
+                let add_entry_block = builder.create_block();
+                let skip_entry_block = builder.create_block();
+                let entry_merge_block = builder.create_block();
+                builder.append_block_param(entry_merge_block, pointer_type);
+                builder.append_block_param(entry_merge_block, ir::types::I64);
+
+                builder
+                    .ins()
+                    .brif(condition_met, add_entry_block, &[], skip_entry_block, &[]);
+
+                // Add entry block
+                builder.switch_to_block(add_entry_block);
+                let key_val = self.lower_expr_with_builder(builder, key, variables)?;
+                let value_val = self.lower_expr_with_builder(builder, value, variables)?;
+                let (new_dict_ptr, new_count) = self.grow_result_dict(
+                    builder,
+                    current_dict_ptr,
+                    current_count,
+                    key_val,
+                    value_val,
+                )?;
+                builder
+                    .ins()
+                    .jump(entry_merge_block, &[new_dict_ptr, new_count]);
+
+                // Skip entry block
+                builder.switch_to_block(skip_entry_block);
+                builder
+                    .ins()
+                    .jump(entry_merge_block, &[current_dict_ptr, current_count]);
+
+                // Merge entry results and continue loop
+                builder.switch_to_block(entry_merge_block);
+                let merged_dict_ptr = builder.block_params(entry_merge_block)[0];
+                let merged_count = builder.block_params(entry_merge_block)[1];
+                let next_index = builder
+                    .ins()
+                    .iadd(current_index, builder.ins().iconst(ir::types::I64, 1));
+                builder
+                    .ins()
+                    .jump(loop_header, &[next_index, merged_dict_ptr, merged_count]);
+
+                // Loop exit
+                builder.switch_to_block(loop_exit);
+                let final_dict_ptr = builder.block_params(loop_exit)[0];
+                builder.ins().jump(result_merge, &[final_dict_ptr]);
+
+                builder.switch_to_block(result_merge);
+                let result = builder.block_params(result_merge)[0];
+
+                builder.seal_block(loop_header);
+                builder.seal_block(loop_body);
+                builder.seal_block(loop_exit);
+                builder.seal_block(add_entry_block);
+                builder.seal_block(skip_entry_block);
+                builder.seal_block(entry_merge_block);
+                builder.seal_block(result_merge);
+
+                Ok(result)
+            }
+            Expr::FString { parts } => {
+                if parts.is_empty() {
+                    // Empty F-string, return empty string
+                    let empty_str =
+                        self.lower_literal_with_builder(builder, &Literal::String("".to_string()))?;
+                    Ok(empty_str)
+                } else {
+                    // For now, implement basic string interpolation by creating a simple concatenated result
+                    // In a full implementation, this would use proper string formatting
+
+                    // For simplicity, concatenate all text parts and ignore expressions for now
+                    let mut concatenated = String::new();
+
+                    for part in &parts {
+                        match part {
+                            ast::nodes::FStringPart::Text(text) => {
+                                concatenated.push_str(text);
+                            }
+                            ast::nodes::FStringPart::Expr(_expr) => {
+                                // TODO: Implement proper expression evaluation and string conversion
+                                concatenated.push_str("<expr>");
+                            }
+                        }
+                    }
+
+                    // Create a string literal with the concatenated result
+                    self.lower_literal_with_builder(builder, &Literal::String(concatenated))
+                }
+            }
+            Expr::Lambda {
+                params,
+                ret_ty,
+                body,
+            } => {
+                // Create an anonymous function for the lambda
+                // For now, this creates a function at module level (not a true closure)
+
+                // Generate a unique name for the lambda function
+                let lambda_name = format!("lambda_{}", self.declared_functions.len());
+
+                // Build signature for the lambda
+                let mut sig = ir::Signature::new(self.isa.default_call_conv());
+
+                // Add parameters
+                for param in &params {
+                    if let Some(param_ty) = &param.ty {
+                        let param_type = self.otter_type_to_cranelift(param_ty)?;
+                        sig.params.push(ir::AbiParam::new(param_type));
+                    } else {
+                        // Default parameter type
+                        sig.params.push(ir::AbiParam::new(ir::types::I64));
+                    }
+                }
+
+                // Add return type
+                if let Some(ret_ty) = &ret_ty {
+                    let ret_type = self.otter_type_to_cranelift(ret_ty)?;
+                    if ret_type != ir::types::INVALID {
+                        sig.returns.push(ir::AbiParam::new(ret_type));
+                    }
+                } else {
+                    // Default return type
+                    sig.returns.push(ir::AbiParam::new(ir::types::I64));
+                }
+
+                // Declare the lambda function
+                let lambda_func_id = self
+                    .module
+                    .declare_function(&lambda_name, cranelift_module::Linkage::Local, &sig)
+                    .map_err(|e| anyhow!("Failed to declare lambda function: {}", e))?;
+
+                self.declared_functions
+                    .insert(lambda_name.clone(), lambda_func_id);
+
+                // Build the lambda function body
+                // Create a new function context for the lambda
+                let mut lambda_ctx = Context::new();
+                lambda_ctx.func.signature = sig.clone();
+
+                // Take the function builder context temporarily
+                let mut fn_builder_ctx = std::mem::take(&mut self.fn_builder_ctx);
+
+                // Create the function builder for the lambda
+                let mut lambda_builder =
+                    FunctionBuilder::new(&mut lambda_ctx.func, &mut fn_builder_ctx);
+
+                // Create entry block for lambda
+                let lambda_entry_block = lambda_builder.create_block();
+                lambda_builder.switch_to_block(lambda_entry_block);
+
+                // Set up variables for lambda parameters
+                let mut lambda_variables = HashMap::new();
+
+                // Declare lambda parameters as variables
+                for (i, param) in params.iter().enumerate() {
+                    let param_value = lambda_builder.block_params(lambda_entry_block)[i];
+                    lambda_variables.insert(param.name.clone(), param_value);
+                }
+
+                // Seal the lambda entry block
+                lambda_builder.seal_block(lambda_entry_block);
+
+                // Lower the lambda body
+                let lambda_result = Self::lower_block_with_builder(
+                    self,
+                    &mut lambda_builder,
+                    &body,
+                    &mut lambda_variables,
+                )?;
+
+                // Return the result from the lambda
+                lambda_builder.ins().return_(&[lambda_result]);
+
+                // Finalize the lambda function
+                lambda_builder.finalize();
+
+                // Restore the function builder context
+                self.fn_builder_ctx = fn_builder_ctx;
+
+                // Define the lambda function in the module
+                self.module
+                    .define_function(lambda_func_id, &mut lambda_ctx)
+                    .map_err(|e| anyhow!("Failed to define lambda function: {}", e))?;
+
+                // Get a pointer to the lambda function for the result
+                let func_addr = self
+                    .module
+                    .get_name(&lambda_name)
+                    .map_err(|e| anyhow!("Failed to get lambda function address: {}", e))?;
+
+                // Convert the function address to a value
+                let lambda_ptr = builder.ins().iconst(ir::types::I64, func_addr as i64);
+
+                Ok(lambda_ptr)
+            }
+            Expr::Await(expr) => {
+                // Await a task/future using tokio runtime
+                let task_handle = self.lower_expr_with_builder(builder, expr, variables)?;
+
+                // Call the await_task builtin function
+                let await_func_id = if let Some(&id) = self.declared_functions.get("await_task") {
+                    id
+                } else {
+                    // Declare await_task function: fn(task_handle: opaque) -> i64
+                    let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                    sig.params.push(ir::AbiParam::new(
+                        self.module.target_config().pointer_type(),
+                    ));
+                    sig.returns.push(ir::AbiParam::new(ir::types::I64));
+
+                    let func_id = self
+                        .module
+                        .declare_function("await_task", cranelift_module::Linkage::Import, &sig)
+                        .map_err(|e| anyhow!("Failed to declare await_task function: {}", e))?;
+
+                    self.declared_functions
+                        .insert("await_task".to_string(), func_id);
+                    func_id
+                };
+
+                // Call await_task
+                let call = self
+                    .module
+                    .declare_func_in_func(await_func_id, builder.func);
+                let result = builder.ins().call(call, &[task_handle]);
+
+                Ok(result)
+            }
+            Expr::Spawn(expr) => {
+                // Spawn a new async task using tokio runtime
+                let task_val = self.lower_expr_with_builder(builder, expr, variables)?;
+
+                // Call the spawn_async builtin function
+                let spawn_func_id = if let Some(&id) = self.declared_functions.get("spawn_async") {
+                    id
+                } else {
+                    // Declare spawn_async function: fn(value: i64) -> opaque
+                    let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                    sig.params.push(ir::AbiParam::new(ir::types::I64));
+                    sig.returns.push(ir::AbiParam::new(
+                        self.module.target_config().pointer_type(),
+                    ));
+
+                    let func_id = self
+                        .module
+                        .declare_function("spawn_async", cranelift_module::Linkage::Import, &sig)
+                        .map_err(|e| anyhow!("Failed to declare spawn_async function: {}", e))?;
+
+                    self.declared_functions
+                        .insert("spawn_async".to_string(), func_id);
+                    func_id
+                };
+
+                // Call spawn_async
+                let call = self
+                    .module
+                    .declare_func_in_func(spawn_func_id, builder.func);
+                let task_handle = builder.ins().call(call, &[task_val]);
+
+                Ok(task_handle)
+            }
+        }
+    }
+
+    /// Lower a literal to Cranelift IR
+    fn lower_literal_with_builder(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lit: &Literal,
+    ) -> Result<ir::Value> {
+        match lit {
+            Literal::Number(num) => {
+                if num.is_float_literal {
+                    Ok(builder.ins().f64const(num.value))
+                } else {
+                    Ok(builder.ins().iconst(ir::types::I64, num.value as i64))
+                }
+            }
+            Literal::Bool(b) => Ok(builder.ins().iconst(ir::types::I8, if *b { 1 } else { 0 })),
+            Literal::String(s) => {
+                // Create a data object for the string literal
+                let data_name = format!("str_lit_{}", self.declared_data.len());
+                let data_id = self.module.declare_data(
+                    &data_name,
+                    cranelift_module::Linkage::Local,
+                    false,
+                    false,
+                )?;
+
+                // Define the data with the string bytes (including null terminator for C compatibility)
+                let mut data_bytes = s.as_bytes().to_vec();
+                data_bytes.push(0); // Null terminator
+
+                self.module.define_data(data_id, &data_bytes)?;
+                self.declared_data.insert(data_name.clone(), data_id);
+
+                // Return a pointer to the string data
+                let global_value = self.module.declare_data_in_func(data_id, builder.func);
+                Ok(builder
+                    .ins()
+                    .global_value(self.module.target_config().pointer_type(), global_value))
+            }
+            Literal::None => Ok(builder.ins().iconst(ir::types::I64, 0)),
+            Literal::Unit => Ok(builder.ins().iconst(ir::types::I64, 0)),
+        }
+    }
+
+    /// Helper method to grow the result array by adding a new element
+    fn grow_result_array(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        current_array: ir::Value,
+        current_count: ir::Value,
+        new_element: ir::Value,
+    ) -> Result<(ir::Value, ir::Value)> {
+        let element_size = 8; // Assume 8-byte elements for now
+
+        // Check if we need to create a new array or grow existing one
+        let create_new_block = builder.create_block();
+        let grow_existing_block = builder.create_block();
+        let merge_block = builder.create_block();
+        builder.append_block_param(merge_block, self.module.target_config().pointer_type());
+        builder.append_block_param(merge_block, ir::types::I64);
+
+        // Check if current array is null (first element)
+        let is_null = builder.ins().icmp(
+            ir::condcodes::IntCC::Equal,
+            current_array,
+            builder.ins().iconst(ir::types::I64, 0),
+        );
+        builder
+            .ins()
+            .brif(is_null, create_new_block, &[], grow_existing_block, &[]);
+
+        // Create new array block (first element)
+        builder.switch_to_block(create_new_block);
+        let new_size = element_size;
+        let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+            id
+        } else {
+            let mut sig = ir::Signature::new(self.isa.default_call_conv());
+            sig.params.push(ir::AbiParam::new(ir::types::I64));
+            sig.returns.push(ir::AbiParam::new(
+                self.module.target_config().pointer_type(),
+            ));
+
+            let func_id = self
+                .module
+                .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+
+            self.declared_functions
+                .insert("malloc".to_string(), func_id);
+            func_id
+        };
+
+        let size_val = builder.ins().iconst(ir::types::I64, new_size + 8); // +8 for length field
+        let malloc_call = self
+            .module
+            .declare_func_in_func(malloc_func_id, builder.func);
+        let new_array = builder.ins().call(malloc_call, &[size_val]);
+
+        // Store length at offset 0
+        let length_addr = new_array;
+        builder.ins().store(
+            ir::MemFlags::new(),
+            builder.ins().iconst(ir::types::I64, 1),
+            length_addr,
+            0,
+        );
+
+        // Store element at offset 8
+        let element_addr = builder
+            .ins()
+            .iadd(new_array, builder.ins().iconst(ir::types::I64, 8));
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), new_element, element_addr, 0);
+
+        let new_count = builder.ins().iconst(ir::types::I64, 1);
+        builder.ins().jump(merge_block, &[new_array, new_count]);
+
+        // Grow existing array block
+        builder.switch_to_block(grow_existing_block);
+        // Create a new larger array with proper length field
+        let new_capacity = builder
+            .ins()
+            .iadd(current_count, builder.ins().iconst(ir::types::I64, 4)); // Add some extra capacity
+        let new_array_size = builder.ins().iadd(
+            builder.ins().iconst(ir::types::I64, 8), // Length field
+            builder.ins().imul(
+                new_capacity,
+                builder.ins().iconst(ir::types::I64, element_size),
+            ),
+        );
+        let grow_malloc_call = self
+            .module
+            .declare_func_in_func(malloc_func_id, builder.func);
+        let grown_array = builder.ins().call(grow_malloc_call, &[new_array_size]);
+
+        // Store updated length at offset 0
+        let new_length = builder
+            .ins()
+            .iadd(current_count, builder.ins().iconst(ir::types::I64, 1));
+        let length_addr = grown_array;
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), new_length, length_addr, 0);
+
+        // Copy existing elements from old array to new array using a loop
+        let copy_loop_header = builder.create_block();
+        let copy_loop_body = builder.create_block();
+        let copy_loop_exit = builder.create_block();
+
+        // Initialize copy index
+        let copy_index = builder.ins().iconst(ir::types::I64, 0);
+
+        // Jump to copy loop header
+        builder.ins().jump(copy_loop_header, &[copy_index]);
+
+        // Copy loop header: check if we've copied all elements
+        builder.switch_to_block(copy_loop_header);
+        let current_copy_index = builder.block_params(copy_loop_header)[0];
+        let should_continue_copy = builder.ins().icmp(
+            ir::condcodes::IntCC::SignedLessThan,
+            current_copy_index,
+            current_count,
+        );
+        builder.ins().brif(
+            should_continue_copy,
+            copy_loop_body,
+            &[],
+            copy_loop_exit,
+            &[],
+        );
+
+        // Copy loop body: copy one element
+        builder.switch_to_block(copy_loop_body);
+
+        // Calculate source address in old array
+        let src_offset = builder.ins().iadd(
+            builder.ins().iconst(ir::types::I64, 8), // Skip length field in source
+            builder.ins().imul(
+                current_copy_index,
+                builder.ins().iconst(ir::types::I64, element_size),
+            ),
+        );
+        let src_addr = builder.ins().iadd(current_array, src_offset);
+        let element_value = builder
+            .ins()
+            .load(ir::types::I64, ir::MemFlags::new(), src_addr, 0);
+
+        // Calculate destination address in new array
+        let dst_offset = builder.ins().iadd(
+            builder.ins().iconst(ir::types::I64, 8), // Skip length field in destination
+            builder.ins().imul(
+                current_copy_index,
+                builder.ins().iconst(ir::types::I64, element_size),
+            ),
+        );
+        let dst_addr = builder.ins().iadd(grown_array, dst_offset);
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), element_value, dst_addr, 0);
+
+        // Increment copy index and loop
+        let next_copy_index = builder
+            .ins()
+            .iadd(current_copy_index, builder.ins().iconst(ir::types::I64, 1));
+        builder.ins().jump(copy_loop_header, &[next_copy_index]);
+
+        // Copy loop exit: now add the new element
+        builder.switch_to_block(copy_loop_exit);
+        let insert_offset = builder.ins().iadd(
+            builder.ins().iconst(ir::types::I64, 8), // Skip length field
+            builder.ins().imul(
+                current_count,
+                builder.ins().iconst(ir::types::I64, element_size),
+            ),
+        );
+        let insert_addr = builder.ins().iadd(grown_array, insert_offset);
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), new_element, insert_addr, 0);
+
+        let updated_count = builder
+            .ins()
+            .iadd(current_count, builder.ins().iconst(ir::types::I64, 1));
+        builder
+            .ins()
+            .jump(merge_block, &[grown_array, updated_count]);
+
+        // Merge results
+        builder.switch_to_block(merge_block);
+        let final_array = builder.block_params(merge_block)[0];
+        let final_count = builder.block_params(merge_block)[1];
+
+        builder.seal_block(create_new_block);
+        builder.seal_block(grow_existing_block);
+        builder.seal_block(copy_loop_header);
+        builder.seal_block(copy_loop_body);
+        builder.seal_block(copy_loop_exit);
+        builder.seal_block(merge_block);
+
+        Ok((final_array, final_count))
+    }
+
+    /// Helper to grow a dictionary by appending a key/value entry
+    fn grow_result_dict(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        current_dict: ir::Value,
+        current_count: ir::Value,
+        key_value: ir::Value,
+        value_value: ir::Value,
+    ) -> Result<(ir::Value, ir::Value)> {
+        let entry_size = 16; // key + value (8 bytes each)
+        let pointer_type = self.module.target_config().pointer_type();
+
+        let create_new_block = builder.create_block();
+        let grow_existing_block = builder.create_block();
+        let merge_block = builder.create_block();
+        builder.append_block_param(merge_block, pointer_type);
+        builder.append_block_param(merge_block, ir::types::I64);
+
+        let null_ptr = builder.ins().iconst(pointer_type, 0);
+        let is_null = builder
+            .ins()
+            .icmp(ir::condcodes::IntCC::Equal, current_dict, null_ptr);
+        builder
+            .ins()
+            .brif(is_null, create_new_block, &[], grow_existing_block, &[]);
+
+        // First entry: allocate storage for one key/value pair
+        builder.switch_to_block(create_new_block);
+        let malloc_func_id = if let Some(&id) = self.declared_functions.get("malloc") {
+            id
+        } else {
+            let mut sig = ir::Signature::new(self.isa.default_call_conv());
+            sig.params.push(ir::AbiParam::new(ir::types::I64));
+            sig.returns.push(ir::AbiParam::new(pointer_type));
+            let func_id = self
+                .module
+                .declare_function("malloc", cranelift_module::Linkage::Import, &sig)
+                .map_err(|e| anyhow!("Failed to declare malloc function: {}", e))?;
+            self.declared_functions
+                .insert("malloc".to_string(), func_id);
+            func_id
+        };
+
+        let size_val = builder.ins().iconst(ir::types::I64, entry_size);
+        let malloc_call = self
+            .module
+            .declare_func_in_func(malloc_func_id, builder.func);
+        let new_dict = builder.ins().call(malloc_call, &[size_val]);
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), key_value, new_dict, 0);
+        let value_addr = builder
+            .ins()
+            .iadd(new_dict, builder.ins().iconst(ir::types::I64, 8));
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), value_value, value_addr, 0);
+        let single_count = builder.ins().iconst(ir::types::I64, 1);
+        builder.ins().jump(merge_block, &[new_dict, single_count]);
+
+        // Append to existing dictionary by allocating a new buffer and copying entries
+        builder.switch_to_block(grow_existing_block);
+        let growth = builder.ins().iconst(ir::types::I64, 4);
+        let new_capacity = builder.ins().iadd(current_count, growth);
+        let new_size = builder.ins().imul(
+            new_capacity,
+            builder.ins().iconst(ir::types::I64, entry_size as i64),
+        );
+        let grow_malloc_call = self
+            .module
+            .declare_func_in_func(malloc_func_id, builder.func);
+        let grown_dict = builder.ins().call(grow_malloc_call, &[new_size]);
+
+        // Copy existing entries one by one
+        let copy_header = builder.create_block();
+        let copy_body = builder.create_block();
+        let copy_exit = builder.create_block();
+        builder.append_block_param(copy_header, ir::types::I64);
+
+        let initial_index = builder.ins().iconst(ir::types::I64, 0);
+        builder.ins().jump(copy_header, &[initial_index]);
+
+        builder.switch_to_block(copy_header);
+        let copy_index = builder.block_params(copy_header)[0];
+        let should_copy = builder.ins().icmp(
+            ir::condcodes::IntCC::SignedLessThan,
+            copy_index,
+            current_count,
+        );
+        builder
+            .ins()
+            .brif(should_copy, copy_body, &[], copy_exit, &[]);
+
+        builder.switch_to_block(copy_body);
+        let entry_offset = builder.ins().imul(
+            copy_index,
+            builder.ins().iconst(ir::types::I64, entry_size as i64),
+        );
+        let src_addr = builder.ins().iadd(current_dict, entry_offset);
+        let src_value_addr = builder
+            .ins()
+            .iadd(src_addr, builder.ins().iconst(ir::types::I64, 8));
+        let key_loaded = builder
+            .ins()
+            .load(ir::types::I64, ir::MemFlags::new(), src_addr, 0);
+        let value_loaded =
+            builder
+                .ins()
+                .load(ir::types::I64, ir::MemFlags::new(), src_value_addr, 0);
+
+        let dst_addr = builder.ins().iadd(grown_dict, entry_offset);
+        let dst_value_addr = builder
+            .ins()
+            .iadd(dst_addr, builder.ins().iconst(ir::types::I64, 8));
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), key_loaded, dst_addr, 0);
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), value_loaded, dst_value_addr, 0);
+
+        let next_copy_index = builder
+            .ins()
+            .iadd(copy_index, builder.ins().iconst(ir::types::I64, 1));
+        builder.ins().jump(copy_header, &[next_copy_index]);
+
+        builder.switch_to_block(copy_exit);
+        let insert_offset = builder.ins().imul(
+            current_count,
+            builder.ins().iconst(ir::types::I64, entry_size as i64),
+        );
+        let insert_addr = builder.ins().iadd(grown_dict, insert_offset);
+        let insert_value_addr = builder
+            .ins()
+            .iadd(insert_addr, builder.ins().iconst(ir::types::I64, 8));
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), key_value, insert_addr, 0);
+        builder
+            .ins()
+            .store(ir::MemFlags::new(), value_value, insert_value_addr, 0);
+        let updated_count = builder
+            .ins()
+            .iadd(current_count, builder.ins().iconst(ir::types::I64, 1));
+        builder
+            .ins()
+            .jump(merge_block, &[grown_dict, updated_count]);
+
+        builder.switch_to_block(merge_block);
+        let merged_dict = builder.block_params(merge_block)[0];
+        let merged_count = builder.block_params(merge_block)[1];
+
+        builder.seal_block(create_new_block);
+        builder.seal_block(grow_existing_block);
+        builder.seal_block(copy_header);
+        builder.seal_block(copy_body);
+        builder.seal_block(copy_exit);
+        builder.seal_block(merge_block);
+
+        Ok((merged_dict, merged_count))
+    }
+
+    /// Lower pattern matching logic
+    fn lower_pattern_match(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        pattern: &ast::nodes::Pattern,
+        value: ir::Value,
+        variables: &mut HashMap<String, ir::Value>,
+    ) -> Result<ir::Value> {
+        match pattern {
+            ast::nodes::Pattern::Wildcard => {
+                // Wildcard always matches
+                Ok(builder.ins().iconst(ir::types::I8, 1))
+            }
+            ast::nodes::Pattern::Literal(lit) => {
+                // Compare value with literal
+                let lit_val = self.lower_literal_with_builder(builder, lit)?;
+                let cmp = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::Equal, value, lit_val);
+                Ok(cmp)
+            }
+            ast::nodes::Pattern::Identifier(name) => {
+                // Bind variable and always match
+                variables.insert(name.clone(), value);
+                Ok(builder.ins().iconst(ir::types::I8, 1))
+            }
+            ast::nodes::Pattern::EnumVariant { .. } => {
+                // TODO: Implement enum variant pattern matching
+                // For now, assume it doesn't match
+                Ok(builder.ins().iconst(ir::types::I8, 0))
+            }
+            ast::nodes::Pattern::Struct { .. } => {
+                // TODO: Implement struct pattern matching
+                // For now, assume it doesn't match
+                Ok(builder.ins().iconst(ir::types::I8, 0))
+            }
+            ast::nodes::Pattern::Array { .. } => {
+                // Safely load array length (null pointer means empty array)
+                let load_length_block = builder.create_block();
+                let length_merge_block = builder.create_block();
+                builder.append_block_param(length_merge_block, ir::types::I64);
+
+                let null_ptr = builder.ins().iconst(ir::types::I64, 0);
+                let is_null = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::Equal, value, null_ptr);
+                builder.ins().brif(
+                    is_null,
+                    length_merge_block,
+                    &[null_ptr],
+                    load_length_block,
+                    &[],
+                );
+
+                builder.switch_to_block(load_length_block);
+                let loaded_length =
+                    builder
+                        .ins()
+                        .load(ir::types::I64, ir::MemFlags::new(), value, 0);
+                builder.ins().jump(length_merge_block, &[loaded_length]);
+
+                builder.switch_to_block(length_merge_block);
+                let array_length = builder.block_params(length_merge_block)[0];
+                let required_len = builder.ins().iconst(ir::types::I64, patterns.len() as i64);
+                let length_ok = if rest.is_some() {
+                    builder.ins().icmp(
+                        ir::condcodes::IntCC::SignedGreaterThanOrEqual,
+                        array_length,
+                        required_len,
+                    )
+                } else {
+                    builder
+                        .ins()
+                        .icmp(ir::condcodes::IntCC::Equal, array_length, required_len)
+                };
+
+                let fail_block = builder.create_block();
+                let match_block = builder.create_block();
+                let merge_block = builder.create_block();
+                builder.append_block_param(merge_block, ir::types::I8);
+
+                builder
+                    .ins()
+                    .brif(length_ok, match_block, &[], fail_block, &[]);
+
+                builder.switch_to_block(fail_block);
+                let fail_val = builder.ins().iconst(ir::types::I8, 0);
+                builder.ins().jump(merge_block, &[fail_val]);
+
+                builder.switch_to_block(match_block);
+                if patterns.is_empty() {
+                    if let Some(rest_name) = rest {
+                        variables.insert(rest_name.clone(), value);
+                    }
+                    let success = builder.ins().iconst(ir::types::I8, 1);
+                    builder.ins().jump(merge_block, &[success]);
+                    builder.seal_block(match_block);
+                } else {
+                    let zero_i8 = builder.ins().iconst(ir::types::I8, 0);
+                    let mut current_block = match_block;
+
+                    for (idx, element_pattern) in patterns.iter().enumerate() {
+                        let next_block = builder.create_block();
+
+                        // Elements start after the length field (8 bytes each)
+                        let element_offset = 8 + (idx as i64) * 8;
+                        let element_addr = builder
+                            .ins()
+                            .iadd(value, builder.ins().iconst(ir::types::I64, element_offset));
+                        let element_val = builder.ins().load(
+                            ir::types::I64,
+                            ir::MemFlags::new(),
+                            element_addr,
+                            0,
+                        );
+
+                        let element_match = self.lower_pattern_match(
+                            builder,
+                            element_pattern,
+                            element_val,
+                            variables,
+                        )?;
+                        let element_passes = builder.ins().icmp(
+                            ir::condcodes::IntCC::NotEqual,
+                            element_match,
+                            zero_i8,
+                        );
+                        builder
+                            .ins()
+                            .brif(element_passes, next_block, &[], fail_block, &[]);
+
+                        builder.seal_block(current_block);
+                        builder.switch_to_block(next_block);
+                        current_block = next_block;
+                    }
+
+                    if let Some(rest_name) = rest {
+                        variables.insert(rest_name.clone(), value);
+                    }
+
+                    let success = builder.ins().iconst(ir::types::I8, 1);
+                    builder.ins().jump(merge_block, &[success]);
+                    builder.seal_block(current_block);
+                }
+
+                builder.seal_block(fail_block);
+                builder.seal_block(merge_block);
+                builder.seal_block(length_merge_block);
+                builder.seal_block(load_length_block);
+
+                builder.switch_to_block(merge_block);
+                let result = builder.block_params(merge_block)[0];
+                Ok(result)
+            }
+        }
+    }
+
+    /// Lower a binary operation (static version)
+    fn lower_binary_op_with_builder(
+        builder: &mut FunctionBuilder,
+        op: BinaryOp,
+        left: ir::Value,
+        right: ir::Value,
+    ) -> Result<ir::Value> {
+        match op {
+            BinaryOp::Add => Ok(builder.ins().iadd(left, right)),
+            BinaryOp::Sub => Ok(builder.ins().isub(left, right)),
+            BinaryOp::Mul => Ok(builder.ins().imul(left, right)),
+            BinaryOp::Div => Ok(builder.ins().sdiv(left, right)),
+            BinaryOp::Eq => {
+                let cmp = builder.ins().icmp(ir::condcodes::IntCC::Equal, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::Ne => {
+                let cmp = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::NotEqual, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::Lt => {
+                let cmp = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::SignedLessThan, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::LtEq => {
+                let cmp =
+                    builder
+                        .ins()
+                        .icmp(ir::condcodes::IntCC::SignedLessThanOrEqual, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::Gt => {
+                let cmp = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::SignedGreaterThan, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::GtEq => {
+                let cmp =
+                    builder
+                        .ins()
+                        .icmp(ir::condcodes::IntCC::SignedGreaterThanOrEqual, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::Is => {
+                // Identity comparison - for now treat as equality
+                let cmp = builder.ins().icmp(ir::condcodes::IntCC::Equal, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::IsNot => {
+                // Identity not-equal - for now treat as inequality
+                let cmp = builder
+                    .ins()
+                    .icmp(ir::condcodes::IntCC::NotEqual, left, right);
+                Ok(cmp)
+            }
+            BinaryOp::And => Ok(builder.ins().band(left, right)), // Bitwise AND
+            BinaryOp::Or => Ok(builder.ins().bor(left, right)),   // Bitwise OR
+            BinaryOp::Mod => Ok(builder.ins().srem(left, right)),
+        }
+    }
+
+    /// Lower a unary operation (static version)
+    fn lower_unary_op_with_builder(
+        builder: &mut FunctionBuilder,
+        op: UnaryOp,
+        val: ir::Value,
+    ) -> Result<ir::Value> {
+        match op {
+            UnaryOp::Neg => Ok(builder.ins().ineg(val)),
+            UnaryOp::Not => {
+                // Logical NOT: compare with 0
+                let zero = builder.ins().iconst(ir::types::I8, 0);
+                Ok(builder.ins().icmp(ir::condcodes::IntCC::Equal, val, zero))
+            }
+        }
+    }
+
+    /// Lower a function call
+    fn lower_call_with_builder(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        func: &Expr,
+        args: &[Expr],
+        variables: &HashMap<String, ir::Value>,
+    ) -> Result<ir::Value> {
+        match func {
+            Expr::Identifier { name, .. } => {
+                // Lower arguments
+                let mut arg_values = Vec::new();
+                for arg in args {
+                    let arg_val = self.lower_expr_with_builder(builder, arg, variables)?;
+                    arg_values.push(arg_val);
+                }
+
+                // For now, just handle built-in functions
+                match name.as_str() {
+                    "print" => {
+                        // Declare external print function if not already declared
+                        let print_func_id = if let Some(&id) = self.declared_functions.get("print")
+                        {
+                            id
+                        } else {
+                            // Declare print function: fn(*const u8) -> ()
+                            let mut sig = ir::Signature::new(self.isa.default_call_conv());
+                            sig.params.push(ir::AbiParam::new(
+                                self.module.target_config().pointer_type(),
+                            ));
+                            sig.returns.push(ir::AbiParam::new(ir::types::INVALID)); // void return
+
+                            let func_id = self
+                                .module
+                                .declare_function("print", cranelift_module::Linkage::Import, &sig)
+                                .map_err(|e| anyhow!("Failed to declare print function: {}", e))?;
+
+                            self.declared_functions.insert("print".to_string(), func_id);
+                            func_id
+                        };
+
+                        // Call the print function
+                        let call = self
+                            .module
+                            .declare_func_in_func(print_func_id, builder.func);
+                        builder.ins().call(call, &arg_values);
+
+                        // Print returns void, so return a dummy value
+                        Ok(builder.ins().iconst(ir::types::I64, 0))
+                    }
+                    _ => bail!("Unknown function: {}", name),
+                }
+            }
+            _ => bail!("Function call on non-identifier not yet supported"),
+        }
+    }
+
+    /// Lower an if expression
+    fn lower_if_expr_with_builder(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        condition: &Expr,
+        then_branch: &Expr,
+        else_branch: &Option<Box<Expr>>,
+        variables: &HashMap<String, ir::Value>,
+    ) -> Result<ir::Value> {
+        // Evaluate condition
+        let cond_val = self.lower_expr_with_builder(builder, condition, variables)?;
+
+        // Create blocks for then, else, and merge
+        let then_block = builder.create_block();
+        let else_block = builder.create_block();
+        let merge_block = builder.create_block();
+
+        // Create a result variable in the merge block
+        let result_type = ir::types::I64; // Default type for now
+        builder.append_block_param(merge_block, result_type);
+
+        // Branch based on condition
+        builder
+            .ins()
+            .brif(cond_val, then_block, &[], else_block, &[]);
+
+        // Then branch
+        builder.switch_to_block(then_block);
+        let then_val = self.lower_expr_with_builder(builder, then_branch, variables)?;
+        builder.ins().jump(merge_block, &[then_val]);
+
+        // Else branch
+        builder.switch_to_block(else_block);
+        let else_val = if let Some(else_expr) = else_branch {
+            self.lower_expr_with_builder(builder, else_expr, variables)?
+        } else {
+            // Default else value
+            builder.ins().iconst(ir::types::I64, 0)
+        };
+        builder.ins().jump(merge_block, &[else_val]);
+
+        // Merge block
+        builder.switch_to_block(merge_block);
+        let result = builder.block_params(merge_block)[0];
+
+        Ok(result)
+    }
+}
+
+impl CodegenBackend for CraneliftBackend {
+    fn declare_function(&mut self, function: &Function) -> Result<FuncId> {
+        let sig = self.build_signature(function)?;
+        let func_id = self
+            .module
+            .declare_function(&function.name, Linkage::Export, &sig)
+            .map_err(|e| anyhow!("Failed to declare function {}: {}", function.name, e))?;
+
+        self.declared_functions
+            .insert(function.name.clone(), func_id);
+        Ok(func_id)
+    }
+
+    fn build_function(&mut self, func_id: FuncId, function: &Function) -> Result<()> {
+        // Create a new function context
+        let mut ctx = Context::new();
+        ctx.func.signature = self.build_signature(function)?;
+
+        // Take the function builder context temporarily
+        let mut fn_builder_ctx = std::mem::take(&mut self.fn_builder_ctx);
+
+        // Create the function builder
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
+
+        // Create entry block
+        let entry_block = builder.create_block();
+        builder.switch_to_block(entry_block);
+
+        // Set up variables for function parameters
+        let mut variables = HashMap::new();
+
+        // Declare function parameters as variables
+        for (i, param) in function.params.iter().enumerate() {
+            let param_value = builder.block_params(entry_block)[i];
+            variables.insert(param.name.clone(), param_value);
+        }
+
+        // Seal the entry block before lowering (required by Cranelift)
+        builder.seal_block(entry_block);
+
+        // Lower the function body
+        let result =
+            Self::lower_block_with_builder(self, &mut builder, &function.body, &mut variables)?;
+
+        // Return the result of the last expression in the block
+        builder.ins().return_(&[result]);
+
+        // Finalize the function
+        builder.finalize();
+
+        // Restore the function builder context
+        self.fn_builder_ctx = fn_builder_ctx;
+
+        // Define the function in the module
+        self.module.define_function(func_id, &mut ctx)?;
+
+        Ok(())
+    }
+
+    fn finalize_module(&mut self) -> Result<CompiledModule> {
+        // Finalize the ObjectModule to get the object bytes
+        let product = self.module.finish();
+        let object_bytes = product
+            .object
+            .write()
+            .map_err(|e| anyhow!("Failed to write object: {}", e))?;
+
+        Ok(CompiledModule {
+            functions: self.declared_functions.clone(),
+            data_objects: self.declared_data.clone(),
+            object_bytes: Some(object_bytes),
+        })
+    }
+
+    fn get_target_info(&self) -> TargetInfo {
+        let triple = self.isa.triple().clone();
+        let pointer_width = self.isa.pointer_bits() as u32;
+        let endianness = match self.isa.endianness() {
+            ir::Endianness::Little => target_lexicon::Endianness::Little,
+            ir::Endianness::Big => target_lexicon::Endianness::Big,
+        };
+
+        TargetInfo {
+            triple,
+            pointer_width,
+            endianness,
+        }
+    }
+
+    fn emit_object_file(&self, path: &Path) -> Result<()> {
+        // First finalize the module to get object bytes
+        let product = self.module.finish();
+        let object_bytes = product
+            .object
+            .write()
+            .map_err(|e| anyhow!("Failed to write object: {}", e))?;
+
+        // Write the object bytes to the file
+        std::fs::write(path, object_bytes)
+            .map_err(|e| anyhow!("Failed to write object file to {}: {}", path.display(), e))?;
+
+        Ok(())
+    }
+
+    fn create_jit_context(&self) -> Result<JitContext> {
+        // Create JIT builder for the target
+        let jit_builder = JITBuilder::new(cranelift_module::default_libcall_names())
+            .map_err(|e| anyhow!("Failed to create JIT builder: {}", e))?;
+
+        // Create JIT module
+        let jit_module = JITModule::new(jit_builder);
+
+        // Copy over declared functions from the object module
+        let mut functions = HashMap::new();
+        for (name, &func_id) in &self.declared_functions {
+            let decl = self.module.declarations().get_function(func_id);
+
+            // Re-declare the function in the JIT module using the same linkage/signature
+            let jit_func_id = jit_module
+                .declare_function(name, decl.linkage, &decl.signature)
+                .map_err(|e| anyhow!("Failed to declare JIT function {}: {}", name, e))?;
+
+            functions.insert(name.clone(), jit_func_id);
+        }
+
+        Ok(JitContext {
+            module: jit_module,
+            functions,
+        })
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2,9 +2,76 @@ pub mod llvm;
 pub mod symbols;
 pub mod target;
 
+#[cfg(feature = "cranelift-backend")]
+use tracing::warn;
+
 pub use llvm::{
     BuildArtifact, CodegenOptLevel, CodegenOptions, build_executable, build_shared_library,
     current_llvm_version,
 };
 pub use symbols::{FfiFunction, FfiSignature, FfiType, SymbolRegistry};
 pub use target::TargetTriple;
+
+// Re-export Cranelift backend when available
+#[cfg(feature = "cranelift-backend")]
+pub mod cranelift;
+#[cfg(feature = "cranelift-backend")]
+pub use cranelift::CraneliftBackend;
+
+/// Codegen backend selection
+#[derive(Debug, Clone, Copy)]
+pub enum CodegenBackendType {
+    LLVM,
+    #[cfg(feature = "cranelift-backend")]
+    Cranelift,
+}
+
+/// Build an executable using the backend specified in options
+pub fn build_executable_with_backend(
+    program: &ast::nodes::Program,
+    expr_types: &std::collections::HashMap<usize, crate::typecheck::TypeInfo>,
+    output: &std::path::Path,
+    options: &CodegenOptions,
+) -> anyhow::Result<BuildArtifact> {
+    match options.backend {
+        CodegenBackendType::LLVM => build_executable(program, expr_types, output, options),
+        #[cfg(feature = "cranelift-backend")]
+        CodegenBackendType::Cranelift => {
+            match cranelift::build_executable(program, expr_types, output, options) {
+                Ok(artifact) => Ok(artifact),
+                Err(err) => {
+                    warn!(
+                        "Cranelift executable build failed ({}); falling back to LLVM",
+                        err
+                    );
+                    build_executable(program, expr_types, output, options)
+                }
+            }
+        }
+    }
+}
+
+/// Build a shared library using the backend specified in options
+pub fn build_shared_library_with_backend(
+    program: &ast::nodes::Program,
+    expr_types: &std::collections::HashMap<usize, crate::typecheck::TypeInfo>,
+    output: &std::path::Path,
+    options: &CodegenOptions,
+) -> anyhow::Result<BuildArtifact> {
+    match options.backend {
+        CodegenBackendType::LLVM => build_shared_library(program, expr_types, output, options),
+        #[cfg(feature = "cranelift-backend")]
+        CodegenBackendType::Cranelift => {
+            match cranelift::build_shared_library(program, expr_types, output, options) {
+                Ok(artifact) => Ok(artifact),
+                Err(err) => {
+                    warn!(
+                        "Cranelift shared library build failed ({}); falling back to LLVM",
+                        err
+                    );
+                    build_shared_library(program, expr_types, output, options)
+                }
+            }
+        }
+    }
+}

--- a/src/runtime/jit/executor.rs
+++ b/src/runtime/jit/executor.rs
@@ -1,3 +1,4 @@
+use crate::codegen::CodegenBackendType;
 use crate::runtime::symbol_registry::SymbolRegistry;
 use anyhow::Result;
 use ast::nodes::Program;
@@ -13,7 +14,15 @@ pub struct JitExecutor {
 
 impl JitExecutor {
     pub fn new(program: Program, symbol_registry: &'static SymbolRegistry) -> Result<Self> {
-        let mut engine = JitEngine::new(symbol_registry)?;
+        Self::new_with_backend(program, symbol_registry, CodegenBackendType::LLVM)
+    }
+
+    pub fn new_with_backend(
+        program: Program,
+        symbol_registry: &'static SymbolRegistry,
+        backend: CodegenBackendType,
+    ) -> Result<Self> {
+        let mut engine = JitEngine::new_with_backend(symbol_registry, backend)?;
         engine.compile_program(&program)?;
 
         Ok(Self { engine, program })

--- a/src/runtime/jit/optimization/call_graph.rs
+++ b/src/runtime/jit/optimization/call_graph.rs
@@ -75,6 +75,31 @@ impl CallGraph {
             .map(|callees| callees.contains(&callee.to_string()))
             .unwrap_or(false)
     }
+
+    /// Return the number of direct callees recorded for `function_name`.
+    pub fn call_count(&self, function_name: &str) -> usize {
+        self.calls
+            .get(function_name)
+            .map(|callees| callees.len())
+            .unwrap_or(0)
+    }
+
+    /// Return the `limit` functions with the highest out-degree in the call graph.
+    /// This acts as a heuristic "hot" list when no profiler guidance is available.
+    pub fn hot_candidates(&self, limit: usize) -> Vec<String> {
+        let mut entries: Vec<_> = self
+            .calls
+            .iter()
+            .map(|(name, callees)| (name.clone(), callees.len()))
+            .collect();
+
+        entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        entries
+            .into_iter()
+            .take(limit)
+            .map(|(name, _)| name)
+            .collect()
+    }
 }
 
 impl Default for CallGraph {

--- a/src/runtime/jit/optimization/inliner.rs
+++ b/src/runtime/jit/optimization/inliner.rs
@@ -1,111 +1,1119 @@
-use ast::nodes::{Block, Expr, Function, Statement};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::call_graph::CallGraph;
+use ast::nodes::{
+    Block, Expr, FStringPart, Function, Literal, MatchArm, Pattern, Program, Statement,
+};
+
+/// Configuration for the inliner.
+#[derive(Debug, Clone)]
+pub struct InlineConfig {
+    /// Maximum number of statements (recursive) a callee may contain to be eligible for inlining.
+    pub max_inline_size: usize,
+    /// Maximum recursive inlining depth to avoid exponential growth.
+    pub max_depth: usize,
+    /// Only inline calls that involve a hot caller/callee pair.
+    pub inline_hot_only: bool,
+}
+
+impl Default for InlineConfig {
+    fn default() -> Self {
+        Self {
+            max_inline_size: 64,
+            max_depth: 3,
+            inline_hot_only: true,
+        }
+    }
+}
+
+/// Summary of inline activity.
+#[derive(Debug, Default, Clone)]
+pub struct InlineStats {
+    pub attempted: usize,
+    pub applied: usize,
+    pub skipped_missing: usize,
+    pub skipped_size: usize,
+    pub skipped_cold: usize,
+    pub skipped_recursive: usize,
+    pub skipped_complex: usize,
+}
 
 /// Inlines function calls for optimization
 pub struct Inliner {
-    max_inline_size: usize,
+    config: InlineConfig,
+    inline_id: AtomicUsize,
 }
 
 impl Inliner {
     pub fn new() -> Self {
+        Self::with_config(InlineConfig::default())
+    }
+
+    pub fn with_config(config: InlineConfig) -> Self {
         Self {
-            max_inline_size: 50, // Don't inline functions larger than 50 statements
+            config,
+            inline_id: AtomicUsize::new(0),
         }
     }
 
-    pub fn should_inline(&self, _caller: &Function, callee: &Function) -> bool {
-        // Simple heuristic: inline small functions called from hot paths
-        let callee_size = self.count_statements(&callee.body);
-        callee_size <= self.max_inline_size
+    pub fn config(&self) -> &InlineConfig {
+        &self.config
     }
 
-    pub fn inline_call(
+    /// Produce an optimized clone of `program` with eligible calls inlined.
+    pub fn inline_program(
         &self,
-        caller: &mut Function,
-        callee: &Function,
-        call_expr: &Expr,
-    ) -> Result<(), String> {
-        // Extract arguments from call expression
-        let args = if let Expr::Call { args, .. } = call_expr {
-            args.clone()
-        } else {
-            return Err("Not a call expression".to_string());
+        program: &Program,
+        hot_functions: &HashSet<String>,
+        call_graph: &CallGraph,
+    ) -> (Program, InlineStats) {
+        let mut stats = InlineStats::default();
+        let mut optimized = program.clone();
+        let function_map = Self::index_functions(program);
+
+        let ctx = InlineContext {
+            function_map: &function_map,
+            hot_functions,
+            call_graph,
         };
 
-        // Clone callee body
-        let mut inlined_body = callee.body.clone();
+        for stmt in &mut optimized.statements {
+            if let Statement::Function(func) = stmt {
+                let mut stack = vec![func.name.clone()];
+                self.inline_function(func, &ctx, &mut stack, &mut stats, 0);
+            }
+        }
 
-        // Replace parameter references with arguments
-        self.substitute_parameters(&mut inlined_body, &callee.params, &args);
-
-        // Insert inlined body into caller
-        // This is a simplified version - a full implementation would need to
-        // handle return values, variable scoping, etc.
-        caller.body.statements.extend(inlined_body.statements);
-
-        Ok(())
+        (optimized, stats)
     }
 
-    fn substitute_parameters(
+    fn inline_function(
+        &self,
+        function: &mut Function,
+        ctx: &InlineContext<'_>,
+        stack: &mut Vec<String>,
+        stats: &mut InlineStats,
+        depth: usize,
+    ) {
+        if depth >= self.config.max_depth {
+            return;
+        }
+        let current_hot = ctx.hot_functions.contains(&function.name);
+        self.inline_block(
+            &mut function.body,
+            ctx,
+            stack,
+            stats,
+            depth,
+            current_hot,
+            &function.name,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn inline_block(
         &self,
         block: &mut Block,
-        params: &[ast::nodes::Param],
-        args: &[Expr],
+        ctx: &InlineContext<'_>,
+        stack: &mut Vec<String>,
+        stats: &mut InlineStats,
+        depth: usize,
+        current_hot: bool,
+        current_name: &str,
     ) {
-        // Simplified parameter substitution
-        // Full implementation would need proper variable renaming to avoid conflicts
-        for stmt in &mut block.statements {
-            self.substitute_in_stmt(stmt, params, args);
+        let mut transformed = Vec::with_capacity(block.statements.len());
+
+        for stmt in block.statements.drain(..) {
+            self.inline_statement(
+                stmt,
+                ctx,
+                stack,
+                stats,
+                depth,
+                current_hot,
+                current_name,
+                &mut transformed,
+            );
         }
+
+        block.statements = transformed;
     }
 
-    fn substitute_in_stmt(
+    #[allow(clippy::too_many_arguments)]
+    fn inline_statement(
         &self,
-        stmt: &mut Statement,
-        params: &[ast::nodes::Param],
-        args: &[Expr],
+        stmt: Statement,
+        ctx: &InlineContext<'_>,
+        stack: &mut Vec<String>,
+        stats: &mut InlineStats,
+        depth: usize,
+        current_hot: bool,
+        current_name: &str,
+        out: &mut Vec<Statement>,
     ) {
-        // Implementation would traverse AST and replace parameter references
-        // This is a placeholder for the full implementation
-        if let Statement::Expr(Expr::Identifier { name, .. }) = stmt
-            && let Some((idx, _)) = params.iter().enumerate().find(|(_, p)| p.name == *name)
-            && idx < args.len()
-        {
-            // This is simplified - would need proper expression replacement
+        match stmt {
+            Statement::Let {
+                name,
+                expr,
+                public,
+                span,
+            } => {
+                let expr_clone = expr.clone();
+                if let Some(mut snippet) = self.try_inline_expr(
+                    expr_clone,
+                    true,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                ) {
+                    self.emit_snippet(&mut snippet, ctx, stack, stats, depth, out);
+                    let value = snippet
+                        .result_expr
+                        .unwrap_or(Expr::Literal(Literal::Unit));
+                    out.push(Statement::Let {
+                        name,
+                        expr: value,
+                        public,
+                        span,
+                    });
+                } else {
+                    let mut expr = expr;
+                    self.inline_expr(
+                        &mut expr,
+                        ctx,
+                        stack,
+                        stats,
+                        depth,
+                        current_hot,
+                        current_name,
+                    );
+                    out.push(Statement::Let {
+                        name,
+                        expr,
+                        public,
+                        span,
+                    });
+                }
+            }
+            Statement::Assignment { name, expr, span } => {
+                let expr_clone = expr.clone();
+                if let Some(mut snippet) = self.try_inline_expr(
+                    expr_clone,
+                    true,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                ) {
+                    self.emit_snippet(&mut snippet, ctx, stack, stats, depth, out);
+                    let value = snippet
+                        .result_expr
+                        .unwrap_or(Expr::Literal(Literal::Unit));
+                    out.push(Statement::Assignment {
+                        name,
+                        expr: value,
+                        span,
+                    });
+                } else {
+                    let mut expr = expr;
+                    self.inline_expr(
+                        &mut expr,
+                        ctx,
+                        stack,
+                        stats,
+                        depth,
+                        current_hot,
+                        current_name,
+                    );
+                    out.push(Statement::Assignment { name, expr, span });
+                }
+            }
+            Statement::Expr(mut expr) => {
+                if let Some(mut snippet) = self.try_inline_expr(
+                    expr.clone(),
+                    false,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                ) {
+                    self.emit_snippet(&mut snippet, ctx, stack, stats, depth, out);
+                } else {
+                    self.inline_expr(
+                        &mut expr,
+                        ctx,
+                        stack,
+                        stats,
+                        depth,
+                        current_hot,
+                        current_name,
+                    );
+                    out.push(Statement::Expr(expr));
+                }
+            }
+            Statement::If {
+                mut cond,
+                mut then_block,
+                mut elif_blocks,
+                mut else_block,
+            } => {
+                self.inline_expr(
+                    &mut cond,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                self.inline_block(
+                    &mut then_block,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                for (_, block) in &mut elif_blocks {
+                    self.inline_block(block, ctx, stack, stats, depth, current_hot, current_name);
+                }
+                if let Some(ref mut blk) = else_block {
+                    self.inline_block(blk, ctx, stack, stats, depth, current_hot, current_name);
+                }
+                out.push(Statement::If {
+                    cond,
+                    then_block,
+                    elif_blocks,
+                    else_block,
+                });
+            }
+            Statement::While { mut cond, mut body } => {
+                self.inline_expr(
+                    &mut cond,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                self.inline_block(
+                    &mut body,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                out.push(Statement::While { cond, body });
+            }
+            Statement::For {
+                var,
+                mut iterable,
+                mut body,
+                var_span,
+            } => {
+                self.inline_expr(
+                    &mut iterable,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                self.inline_block(
+                    &mut body,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                out.push(Statement::For {
+                    var,
+                    iterable,
+                    body,
+                    var_span,
+                });
+            }
+            Statement::Block(mut inner) => {
+                self.inline_block(
+                    &mut inner,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                out.push(Statement::Block(inner));
+            }
+            Statement::Try {
+                mut body,
+                mut handlers,
+                mut else_block,
+                mut finally_block,
+            } => {
+                self.inline_block(
+                    &mut body,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                for handler in &mut handlers {
+                    self.inline_block(
+                        &mut handler.body,
+                        ctx,
+                        stack,
+                        stats,
+                        depth,
+                        current_hot,
+                        current_name,
+                    );
+                }
+                if let Some(ref mut blk) = else_block {
+                    self.inline_block(blk, ctx, stack, stats, depth, current_hot, current_name);
+                }
+                if let Some(ref mut blk) = finally_block {
+                    self.inline_block(blk, ctx, stack, stats, depth, current_hot, current_name);
+                }
+                out.push(Statement::Try {
+                    body,
+                    handlers,
+                    else_block,
+                    finally_block,
+                });
+            }
+            other => out.push(other),
         }
     }
 
-    fn count_statements(&self, block: &Block) -> usize {
-        block.statements.iter().map(|s| self.count_in_stmt(s)).sum()
-    }
-
-    fn count_in_stmt(&self, stmt: &Statement) -> usize {
-        match stmt {
-            Statement::If {
-                then_block,
-                elif_blocks,
-                else_block,
+    #[allow(clippy::too_many_arguments)]
+    fn inline_expr(
+        &self,
+        expr: &mut Expr,
+        ctx: &InlineContext<'_>,
+        stack: &mut Vec<String>,
+        stats: &mut InlineStats,
+        depth: usize,
+        current_hot: bool,
+        current_name: &str,
+    ) {
+        match expr {
+            Expr::Call { func, args } => {
+                self.inline_expr(func, ctx, stack, stats, depth, current_hot, current_name);
+                for arg in args {
+                    self.inline_expr(arg, ctx, stack, stats, depth, current_hot, current_name);
+                }
+            }
+            Expr::Binary { left, right, .. } => {
+                self.inline_expr(left, ctx, stack, stats, depth, current_hot, current_name);
+                self.inline_expr(right, ctx, stack, stats, depth, current_hot, current_name);
+            }
+            Expr::Unary { expr: inner, .. } => {
+                self.inline_expr(inner, ctx, stack, stats, depth, current_hot, current_name);
+            }
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.inline_expr(cond, ctx, stack, stats, depth, current_hot, current_name);
+                self.inline_expr(
+                    then_branch,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                if let Some(branch) = else_branch.as_mut() {
+                    self.inline_expr(branch, ctx, stack, stats, depth, current_hot, current_name);
+                }
+            }
+            Expr::Match { value, arms } => {
+                self.inline_expr(value, ctx, stack, stats, depth, current_hot, current_name);
+                for arm in arms {
+                    if let Some(guard) = &mut arm.guard {
+                        self.inline_expr(
+                            guard,
+                            ctx,
+                            stack,
+                            stats,
+                            depth,
+                            current_hot,
+                            current_name,
+                        );
+                    }
+                    self.inline_expr(
+                        &mut arm.body,
+                        ctx,
+                        stack,
+                        stats,
+                        depth,
+                        current_hot,
+                        current_name,
+                    );
+                }
+            }
+            Expr::Array(values) => {
+                for value in values {
+                    self.inline_expr(value, ctx, stack, stats, depth, current_hot, current_name);
+                }
+            }
+            Expr::Dict(pairs) => {
+                for (key, value) in pairs {
+                    self.inline_expr(key, ctx, stack, stats, depth, current_hot, current_name);
+                    self.inline_expr(value, ctx, stack, stats, depth, current_hot, current_name);
+                }
+            }
+            Expr::ListComprehension {
+                element,
+                iterable,
+                condition,
                 ..
             } => {
-                let mut count = 1;
-                count += self.count_statements(then_block);
-                for (_, block) in elif_blocks {
-                    count += self.count_statements(block);
+                self.inline_expr(element, ctx, stack, stats, depth, current_hot, current_name);
+                self.inline_expr(
+                    iterable,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                if let Some(cond) = condition {
+                    self.inline_expr(cond, ctx, stack, stats, depth, current_hot, current_name);
                 }
-                if let Some(block) = else_block {
-                    count += self.count_statements(block);
+            }
+            Expr::DictComprehension {
+                key,
+                value,
+                iterable,
+                condition,
+                ..
+            } => {
+                self.inline_expr(key, ctx, stack, stats, depth, current_hot, current_name);
+                self.inline_expr(value, ctx, stack, stats, depth, current_hot, current_name);
+                self.inline_expr(
+                    iterable,
+                    ctx,
+                    stack,
+                    stats,
+                    depth,
+                    current_hot,
+                    current_name,
+                );
+                if let Some(cond) = condition {
+                    self.inline_expr(cond, ctx, stack, stats, depth, current_hot, current_name);
                 }
-                count
             }
-            Statement::For { body, .. } | Statement::While { body, .. } => {
-                1 + self.count_statements(body)
+            Expr::FString { parts } => {
+                for part in parts {
+                    if let FStringPart::Expr(expr) = part {
+                        self.inline_expr(expr, ctx, stack, stats, depth, current_hot, current_name);
+                    }
+                }
             }
-            _ => 1,
+            Expr::Lambda { body, .. } => {
+                self.inline_block(body, ctx, stack, stats, depth, current_hot, current_name);
+            }
+            Expr::Spawn(expr) | Expr::Await(expr) => {
+                self.inline_expr(expr, ctx, stack, stats, depth, current_hot, current_name);
+            }
+            Expr::Struct { fields, .. } => {
+                for (_, value) in fields {
+                    self.inline_expr(value, ctx, stack, stats, depth, current_hot, current_name);
+                }
+            }
+            _ => {}
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_inline_expr(
+        &self,
+        expr: Expr,
+        needs_result: bool,
+        ctx: &InlineContext<'_>,
+        stack: &mut [String],
+        stats: &mut InlineStats,
+        depth: usize,
+        current_hot: bool,
+        current_name: &str,
+    ) -> Option<InlineSnippet> {
+        if let Expr::Call { func, args } = expr
+            && let Expr::Identifier { name, .. } = *func
+        {
+            return self.try_inline_call(
+                &name,
+                args,
+                ctx,
+                stack,
+                stats,
+                depth,
+                current_hot,
+                current_name,
+                needs_result,
+            );
+        }
+        None
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_inline_call(
+        &self,
+        callee_name: &str,
+        args: Vec<Expr>,
+        ctx: &InlineContext<'_>,
+        stack: &mut [String],
+        stats: &mut InlineStats,
+        _depth: usize,
+        current_hot: bool,
+        _current_name: &str,
+        needs_result: bool,
+    ) -> Option<InlineSnippet> {
+        stats.attempted += 1;
+
+        let callee = match ctx.function_map.get(callee_name) {
+            Some(func) => func,
+            None => {
+                stats.skipped_missing += 1;
+                return None;
+            }
+        };
+
+        if args.len() != callee.params.len() {
+            stats.skipped_complex += 1;
+            return None;
+        }
+
+        if stack.contains(&callee_name.to_string()) {
+            stats.skipped_recursive += 1;
+            return None;
+        }
+
+        if self.config.inline_hot_only && !current_hot && !ctx.hot_functions.contains(callee_name) {
+            stats.skipped_cold += 1;
+            return None;
+        }
+
+        let size = callee.body.recursive_count();
+        if size > self.config.max_inline_size {
+            stats.skipped_size += 1;
+            return None;
+        }
+
+        if Self::has_internal_return(&callee.body) {
+            stats.skipped_complex += 1;
+            return None;
+        }
+
+        let inline_id = self.next_inline_id();
+        let mut builder = InlineBuilder::new(inline_id);
+        let snippet = builder.build_snippet(callee, &args);
+
+        if needs_result && snippet.result_expr.is_none() {
+            stats.skipped_complex += 1;
+            return None;
+        }
+
+        stats.applied += 1;
+        Some(InlineSnippet {
+            callee: callee_name.to_string(),
+            block: snippet.block,
+            result_expr: snippet.result_expr,
+        })
+    }
+
+    fn emit_snippet(
+        &self,
+        snippet: &mut InlineSnippet,
+        ctx: &InlineContext<'_>,
+        stack: &mut Vec<String>,
+        stats: &mut InlineStats,
+        depth: usize,
+        out: &mut Vec<Statement>,
+    ) {
+        stack.push(snippet.callee.clone());
+        let callee_hot = ctx.hot_functions.contains(&snippet.callee);
+        self.inline_block(
+            &mut snippet.block,
+            ctx,
+            stack,
+            stats,
+            depth + 1,
+            callee_hot,
+            &snippet.callee,
+        );
+        stack.pop();
+
+        out.append(&mut snippet.block.statements);
+    }
+
+    fn has_internal_return(block: &Block) -> bool {
+        if block.statements.is_empty() {
+            return false;
+        }
+
+        for (idx, stmt) in block.statements.iter().enumerate() {
+            let is_last = idx == block.statements.len() - 1;
+            match stmt {
+                Statement::Return(_) => {
+                    if !is_last {
+                        return true;
+                    }
+                }
+                Statement::If {
+                    then_block,
+                    elif_blocks,
+                    else_block,
+                    ..
+                } => {
+                    if Self::has_internal_return(then_block) {
+                        return true;
+                    }
+                    for (_, block) in elif_blocks {
+                        if Self::has_internal_return(block) {
+                            return true;
+                        }
+                    }
+                    if let Some(block) = else_block
+                        && Self::has_internal_return(block)
+                    {
+                        return true;
+                    }
+                }
+                Statement::While { body, .. }
+                | Statement::For { body, .. }
+                | Statement::Block(body) => {
+                    if Self::has_internal_return(body) {
+                        return true;
+                    }
+                }
+                Statement::Try {
+                    body,
+                    handlers,
+                    else_block,
+                    finally_block,
+                } => {
+                    if Self::has_internal_return(body) {
+                        return true;
+                    }
+                    for handler in handlers {
+                        if Self::has_internal_return(&handler.body) {
+                            return true;
+                        }
+                    }
+                    if let Some(block) = else_block
+                        && Self::has_internal_return(block)
+                    {
+                        return true;
+                    }
+                    if let Some(block) = finally_block
+                        && Self::has_internal_return(block)
+                    {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
+
+    fn next_inline_id(&self) -> usize {
+        self.inline_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn index_functions(program: &Program) -> HashMap<String, Function> {
+        let mut map = HashMap::new();
+        for stmt in &program.statements {
+            if let Statement::Function(func) = stmt {
+                map.insert(func.name.clone(), func.clone());
+            }
+        }
+        map
     }
 }
 
 impl Default for Inliner {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+struct InlineSnippet {
+    callee: String,
+    block: Block,
+    result_expr: Option<Expr>,
+}
+
+struct InlineContext<'a> {
+    function_map: &'a HashMap<String, Function>,
+    hot_functions: &'a HashSet<String>,
+    #[allow(dead_code)]
+    call_graph: &'a CallGraph,
+}
+
+struct BuiltSnippet {
+    block: Block,
+    result_expr: Option<Expr>,
+}
+
+struct InlineBuilder {
+    names: InlineNameGenerator,
+}
+
+impl InlineBuilder {
+    fn new(inline_id: usize) -> Self {
+        Self {
+            names: InlineNameGenerator::new(inline_id),
+        }
+    }
+
+    fn build_snippet(&mut self, callee: &Function, args: &[Expr]) -> BuiltSnippet {
+        let mut statements = Vec::new();
+        let inline_id = self.names.id();
+        for (idx, param) in callee.params.iter().enumerate() {
+            let arg = args[idx].clone();
+            let param_name = self
+                .names
+                .register_param(&param.name, format!("__inl{}_arg{}", inline_id, idx));
+            statements.push(Statement::Let {
+                name: param_name,
+                expr: arg,
+                public: false,
+                span: param.span,
+            });
+        }
+
+        let body = self.rewrite_body(&callee.body);
+        statements.extend(body.statements);
+
+        BuiltSnippet {
+            block: Block { statements },
+            result_expr: body.return_expr,
+        }
+    }
+
+    fn rewrite_body(&mut self, block: &Block) -> InlineBody {
+        let mut statements = Vec::new();
+        let tail_return = block.statements.last().and_then(|stmt| match stmt {
+            Statement::Return(expr) => expr.clone(),
+            _ => None,
+        });
+
+        let tail_index = block.statements.len().saturating_sub(1);
+
+        for (idx, stmt) in block.statements.iter().enumerate() {
+            if matches!(stmt, Statement::Return(_)) && idx == tail_index {
+                break;
+            }
+            statements.push(self.rewrite_statement(stmt));
+        }
+
+        InlineBody {
+            statements,
+            return_expr: tail_return.map(|expr| self.rewrite_expr(&expr)),
+        }
+    }
+
+    fn rewrite_statement(&mut self, stmt: &Statement) -> Statement {
+        match stmt {
+            Statement::Let {
+                name,
+                expr,
+                public,
+                span,
+            } => Statement::Let {
+                name: self.names.rename_local(name),
+                expr: self.rewrite_expr(expr),
+                public: *public,
+                span: *span,
+            },
+            Statement::Assignment { name, expr, span } => Statement::Assignment {
+                name: self.names.resolve_or_clone(name),
+                expr: self.rewrite_expr(expr),
+                span: *span,
+            },
+            Statement::Expr(expr) => Statement::Expr(self.rewrite_expr(expr)),
+            Statement::If {
+                cond,
+                then_block,
+                elif_blocks,
+                else_block,
+            } => Statement::If {
+                cond: Box::new(self.rewrite_expr(cond)),
+                then_block: self.rewrite_nested_block(then_block),
+                elif_blocks: elif_blocks
+                    .iter()
+                    .map(|(cond, block)| {
+                        (self.rewrite_expr(cond), self.rewrite_nested_block(block))
+                    })
+                    .collect(),
+                else_block: else_block
+                    .as_ref()
+                    .map(|block| self.rewrite_nested_block(block)),
+            },
+            Statement::For {
+                var,
+                iterable,
+                body,
+                var_span,
+            } => Statement::For {
+                var: self.names.rename_local(var),
+                iterable: self.rewrite_expr(iterable),
+                body: self.rewrite_nested_block(body),
+                var_span: *var_span,
+            },
+            Statement::While { cond, body } => Statement::While {
+                cond: self.rewrite_expr(cond),
+                body: self.rewrite_nested_block(body),
+            },
+            Statement::Block(block) => Statement::Block(self.rewrite_nested_block(block)),
+            Statement::Try {
+                body,
+                handlers,
+                else_block,
+                finally_block,
+            } => Statement::Try {
+                body: self.rewrite_nested_block(body),
+                handlers: handlers
+                    .iter()
+                    .map(|handler| {
+                        let mut new_handler = handler.clone();
+                        new_handler.body = self.rewrite_nested_block(&handler.body);
+                        new_handler
+                    })
+                    .collect(),
+                else_block: else_block
+                    .as_ref()
+                    .map(|block| self.rewrite_nested_block(block)),
+                finally_block: finally_block
+                    .as_ref()
+                    .map(|block| self.rewrite_nested_block(block)),
+            },
+            other => other.clone(),
+        }
+    }
+
+    fn rewrite_nested_block(&mut self, block: &Block) -> Block {
+        let mut statements = Vec::with_capacity(block.statements.len());
+        for stmt in &block.statements {
+            statements.push(self.rewrite_statement(stmt));
+        }
+        Block { statements }
+    }
+
+    fn rewrite_expr(&mut self, expr: &Expr) -> Expr {
+        match expr {
+            Expr::Identifier { name, span } => Expr::Identifier {
+                name: self.names.resolve_or_clone(name),
+                span: *span,
+            },
+            Expr::Binary { op, left, right } => Expr::Binary {
+                op: *op,
+                left: Box::new(self.rewrite_expr(left)),
+                right: Box::new(self.rewrite_expr(right)),
+            },
+            Expr::Unary { op, expr } => Expr::Unary {
+                op: *op,
+                expr: Box::new(self.rewrite_expr(expr)),
+            },
+            Expr::Call { func, args } => Expr::Call {
+                func: Box::new(self.rewrite_expr(func)),
+                args: args.iter().map(|arg| self.rewrite_expr(arg)).collect(),
+            },
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => Expr::If {
+                cond: Box::new(self.rewrite_expr(cond)),
+                then_branch: Box::new(self.rewrite_expr(then_branch)),
+                else_branch: else_branch
+                    .as_ref()
+                    .map(|branch| Box::new(self.rewrite_expr(branch))),
+            },
+            Expr::Match { value, arms } => Expr::Match {
+                value: Box::new(self.rewrite_expr(value)),
+                arms: arms
+                    .iter()
+                    .map(|arm| MatchArm {
+                        pattern: self.rewrite_pattern(&arm.pattern),
+                        guard: arm.guard.as_ref().map(|g| self.rewrite_expr(g)),
+                        body: self.rewrite_expr(&arm.body),
+                    })
+                    .collect(),
+            },
+            Expr::Array(values) => Expr::Array(
+                values
+                    .iter()
+                    .map(|value| self.rewrite_expr(value))
+                    .collect(),
+            ),
+            Expr::Dict(pairs) => Expr::Dict(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (self.rewrite_expr(k), self.rewrite_expr(v)))
+                    .collect(),
+            ),
+            Expr::ListComprehension {
+                element,
+                var,
+                iterable,
+                condition,
+            } => Expr::ListComprehension {
+                element: Box::new(self.rewrite_expr(element)),
+                var: self.names.rename_local(var),
+                iterable: Box::new(self.rewrite_expr(iterable)),
+                condition: condition
+                    .as_ref()
+                    .map(|cond| Box::new(self.rewrite_expr(cond))),
+            },
+            Expr::DictComprehension {
+                key,
+                value,
+                var,
+                iterable,
+                condition,
+            } => Expr::DictComprehension {
+                key: Box::new(self.rewrite_expr(key)),
+                value: Box::new(self.rewrite_expr(value)),
+                var: self.names.rename_local(var),
+                iterable: Box::new(self.rewrite_expr(iterable)),
+                condition: condition
+                    .as_ref()
+                    .map(|cond| Box::new(self.rewrite_expr(cond))),
+            },
+            Expr::FString { parts } => Expr::FString {
+                parts: parts
+                    .iter()
+                    .map(|part| match part {
+                        FStringPart::Expr(expr) => {
+                            FStringPart::Expr(Box::new(self.rewrite_expr(expr)))
+                        }
+                        FStringPart::Text(text) => FStringPart::Text(text.clone()),
+                    })
+                    .collect(),
+            },
+            Expr::Lambda {
+                params,
+                ret_ty,
+                body,
+            } => Expr::Lambda {
+                params: params.clone(),
+                ret_ty: ret_ty.clone(),
+                body: self.rewrite_nested_block(body),
+            },
+            Expr::Spawn(expr) => Expr::Spawn(Box::new(self.rewrite_expr(expr))),
+            Expr::Await(expr) => Expr::Await(Box::new(self.rewrite_expr(expr))),
+            Expr::Struct { name, fields } => Expr::Struct {
+                name: name.clone(),
+                fields: fields
+                    .iter()
+                    .map(|(field, value)| (field.clone(), self.rewrite_expr(value)))
+                    .collect(),
+            },
+            _ => expr.clone(),
+        }
+    }
+
+    fn rewrite_pattern(&mut self, pattern: &Pattern) -> Pattern {
+        match pattern {
+            Pattern::Identifier(name) => Pattern::Identifier(self.names.rename_local(name)),
+            Pattern::Struct { name, fields } => Pattern::Struct {
+                name: name.clone(),
+                fields: fields
+                    .iter()
+                    .map(|(field, pat)| {
+                        (
+                            field.clone(),
+                            pat.as_ref().map(|inner| self.rewrite_pattern(inner)),
+                        )
+                    })
+                    .collect(),
+            },
+            Pattern::Array { patterns, rest } => Pattern::Array {
+                patterns: patterns
+                    .iter()
+                    .map(|pat| self.rewrite_pattern(pat))
+                    .collect(),
+                rest: rest.as_ref().map(|name| self.names.rename_local(name)),
+            },
+            Pattern::EnumVariant {
+                enum_name,
+                variant,
+                fields,
+            } => Pattern::EnumVariant {
+                enum_name: enum_name.clone(),
+                variant: variant.clone(),
+                fields: fields.iter().map(|pat| self.rewrite_pattern(pat)).collect(),
+            },
+            _ => pattern.clone(),
+        }
+    }
+}
+
+struct InlineBody {
+    statements: Vec<Statement>,
+    return_expr: Option<Expr>,
+}
+
+struct InlineNameGenerator {
+    inline_id: usize,
+    counter: usize,
+    map: HashMap<String, String>,
+}
+
+impl InlineNameGenerator {
+    fn new(inline_id: usize) -> Self {
+        Self {
+            inline_id,
+            counter: 0,
+            map: HashMap::new(),
+        }
+    }
+
+    fn id(&self) -> usize {
+        self.inline_id
+    }
+
+    fn register_param(&mut self, original: &str, replacement: String) -> String {
+        self.map.insert(original.to_string(), replacement.clone());
+        replacement
+    }
+
+    fn rename_local(&mut self, original: &str) -> String {
+        let name = format!("__inl{}_{}_{}", self.inline_id, original, self.counter);
+        self.counter += 1;
+        self.map.insert(original.to_string(), name.clone());
+        name
+    }
+
+    fn resolve_or_clone(&self, original: &str) -> String {
+        self.map
+            .get(original)
+            .cloned()
+            .unwrap_or_else(|| original.to_string())
     }
 }

--- a/src/runtime/jit/optimization/reoptimizer.rs
+++ b/src/runtime/jit/optimization/reoptimizer.rs
@@ -1,51 +1,522 @@
+use std::collections::HashSet;
+
 use super::call_graph::CallGraph;
+use super::inliner::{InlineConfig, Inliner};
 use crate::codegen::CodegenOptLevel;
-use ast::nodes::{Function, Program};
+use ast::nodes::{
+    BinaryOp, Block, Expr, FStringPart, Function, Literal, NumberLiteral, Program, Statement,
+    UnaryOp,
+};
 
 /// Re-optimizes hot functions
 pub struct Reoptimizer {
     #[allow(dead_code)]
     opt_level: CodegenOptLevel,
+    hot_functions: HashSet<String>,
+    inliner: Inliner,
 }
 
 impl Reoptimizer {
     pub fn new() -> Self {
-        Self {
-            opt_level: CodegenOptLevel::Aggressive,
-        }
+        Self::with_opt_level(CodegenOptLevel::Aggressive)
     }
 
     pub fn with_opt_level(opt_level: CodegenOptLevel) -> Self {
-        Self { opt_level }
+        let inline_config = match opt_level {
+            CodegenOptLevel::None => InlineConfig {
+                max_inline_size: 24,
+                max_depth: 1,
+                inline_hot_only: true,
+            },
+            CodegenOptLevel::Default => InlineConfig {
+                max_inline_size: 48,
+                max_depth: 2,
+                inline_hot_only: true,
+            },
+            CodegenOptLevel::Aggressive => InlineConfig {
+                max_inline_size: 80,
+                max_depth: 3,
+                inline_hot_only: false,
+            },
+        };
+
+        Self {
+            opt_level,
+            hot_functions: HashSet::new(),
+            inliner: Inliner::with_config(inline_config),
+        }
     }
 
-    /// Re-optimize a function with aggressive optimizations
+    /// Provide an explicit set of hot functions discovered by the profiler.
+    pub fn set_hot_functions<I, S>(&mut self, hot: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.hot_functions = hot.into_iter().map(|s| s.into()).collect();
+    }
+
+    pub fn inliner(&self) -> &Inliner {
+        &self.inliner
+    }
+
+    /// Re-optimize a function by applying aggressive but semantics-preserving cleanups.
     pub fn reoptimize_function(&self, function: &Function) -> Function {
-        // For now, return as-is
-        // In a full implementation, we would:
-        // 1. Apply aggressive optimizations (constant folding, dead code elimination, etc.)
-        // 2. Optimize based on runtime profiling data
-        // 3. Restructure code for better cache locality
-        function.clone()
+        let mut optimized = function.clone();
+        self.clean_block(&mut optimized.body);
+        optimized
     }
 
-    /// Optimize hot call paths
-    pub fn optimize_hot_paths(&self, program: &Program, _call_graph: &CallGraph) -> Program {
-        // Identify hot call paths and optimize them
-        // This would involve:
-        // 1. Finding frequently called function chains
-        // 2. Inlining hot paths
-        // 3. Reordering code for better locality
-        program.clone()
+    /// Optimize hot call paths by inlining and running post-inline cleanups.
+    pub fn optimize_hot_paths(&self, program: &Program, call_graph: &CallGraph) -> Program {
+        let hot_candidates = if self.hot_functions.is_empty() {
+            call_graph.hot_candidates(8)
+        } else {
+            self.hot_functions.iter().cloned().collect()
+        };
+        let hot_set: HashSet<String> = hot_candidates.into_iter().collect();
+
+        let (mut optimized, _) = self.inliner.inline_program(program, &hot_set, call_graph);
+
+        for stmt in &mut optimized.statements {
+            if let Statement::Function(func) = stmt {
+                if hot_set.contains(&func.name) {
+                    *func = self.post_inline_optimize(func);
+                } else {
+                    *func = self.reoptimize_function(func);
+                }
+            }
+        }
+
+        optimized
     }
 
-    /// Apply post-inline optimizations
+    /// Apply post-inline optimizations such as dead-code elimination and block flattening.
     pub fn post_inline_optimize(&self, function: &Function) -> Function {
-        // After inlining, we can apply additional optimizations:
-        // 1. Remove redundant operations
-        // 2. Simplify expressions
-        // 3. Eliminate dead code
-        function.clone()
+        let mut optimized = function.clone();
+        self.clean_block(&mut optimized.body);
+        self.prune_empty_blocks(&mut optimized.body);
+        optimized
+    }
+
+    fn clean_block(&self, block: &mut Block) {
+        self.fold_constants_in_block(block);
+        self.remove_dead_statements(block);
+    }
+
+    fn fold_constants_in_block(&self, block: &mut Block) {
+        let mut rewritten = Vec::with_capacity(block.statements.len());
+        for mut stmt in block.statements.drain(..) {
+            self.fold_constants_in_statement(&mut stmt);
+            match self.simplify_statement(stmt) {
+                StatementTransform::Single(stmt) => rewritten.push(stmt),
+                StatementTransform::Many(stmts) => rewritten.extend(stmts),
+                StatementTransform::None => {}
+            }
+        }
+        block.statements = rewritten;
+    }
+
+    fn fold_constants_in_statement(&self, stmt: &mut Statement) {
+        match stmt {
+            Statement::Let { expr, .. }
+            | Statement::Assignment { expr, .. }
+            | Statement::Expr(expr)
+            | Statement::Return(Some(expr))
+            | Statement::Raise(Some(expr)) => {
+                self.fold_constants_in_expr(expr);
+            }
+            Statement::If {
+                cond,
+                then_block,
+                elif_blocks,
+                else_block,
+            } => {
+                self.fold_constants_in_expr(cond);
+                self.fold_constants_in_block(then_block);
+                for (_, block) in elif_blocks {
+                    self.fold_constants_in_block(block);
+                }
+                if let Some(block) = else_block {
+                    self.fold_constants_in_block(block);
+                }
+            }
+            Statement::While { cond, body } => {
+                self.fold_constants_in_expr(cond);
+                self.fold_constants_in_block(body);
+            }
+            Statement::For { iterable, body, .. } => {
+                self.fold_constants_in_expr(iterable);
+                self.fold_constants_in_block(body);
+            }
+            Statement::Block(inner) => self.fold_constants_in_block(inner),
+            Statement::Try {
+                body,
+                handlers,
+                else_block,
+                finally_block,
+            } => {
+                self.fold_constants_in_block(body);
+                for handler in handlers {
+                    self.fold_constants_in_block(&mut handler.body);
+                }
+                if let Some(block) = else_block {
+                    self.fold_constants_in_block(block);
+                }
+                if let Some(block) = finally_block {
+                    self.fold_constants_in_block(block);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn fold_constants_in_expr(&self, expr: &mut Expr) -> Option<Literal> {
+        match expr {
+            Expr::Literal(lit) => Some(lit.clone()),
+            Expr::Unary { op, expr: inner } => {
+                let literal = self.fold_constants_in_expr(inner);
+                if let Some(lit) = literal
+                    && let Some(new_lit) = Self::eval_unary(*op, &lit)
+                {
+                    *expr = Expr::Literal(new_lit.clone());
+                    return Some(new_lit);
+                }
+                None
+            }
+            Expr::Binary { op, left, right } => {
+                let left_lit = self.fold_constants_in_expr(left);
+                let right_lit = self.fold_constants_in_expr(right);
+                if let (Some(l), Some(r)) = (left_lit, right_lit)
+                    && let Some(new_lit) = Self::eval_binary(*op, &l, &r)
+                {
+                    *expr = Expr::Literal(new_lit.clone());
+                    return Some(new_lit);
+                }
+                None
+            }
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                let cond_lit = self.fold_constants_in_expr(cond);
+                self.fold_constants_in_expr(then_branch);
+                if let Some(branch) = else_branch.as_mut() {
+                    self.fold_constants_in_expr(branch);
+                }
+                if let Some(Literal::Bool(value)) = cond_lit {
+                    let replacement = if value {
+                        *then_branch.clone()
+                    } else if let Some(branch) = else_branch {
+                        *branch.clone()
+                    } else {
+                        Expr::Literal(Literal::Unit)
+                    };
+                    *expr = replacement;
+                }
+                None
+            }
+            Expr::Call { func, args } => {
+                self.fold_constants_in_expr(func);
+                for arg in args {
+                    self.fold_constants_in_expr(arg);
+                }
+                None
+            }
+            Expr::Array(values) => {
+                for value in values {
+                    self.fold_constants_in_expr(value);
+                }
+                None
+            }
+            Expr::Dict(pairs) => {
+                for (key, value) in pairs {
+                    self.fold_constants_in_expr(key);
+                    self.fold_constants_in_expr(value);
+                }
+                None
+            }
+            Expr::ListComprehension {
+                element,
+                iterable,
+                condition,
+                ..
+            } => {
+                self.fold_constants_in_expr(element);
+                self.fold_constants_in_expr(iterable);
+                if let Some(cond) = condition {
+                    self.fold_constants_in_expr(cond);
+                }
+                None
+            }
+            Expr::DictComprehension {
+                key,
+                value,
+                iterable,
+                condition,
+                ..
+            } => {
+                self.fold_constants_in_expr(key);
+                self.fold_constants_in_expr(value);
+                self.fold_constants_in_expr(iterable);
+                if let Some(cond) = condition {
+                    self.fold_constants_in_expr(cond);
+                }
+                None
+            }
+            Expr::Match { value, arms } => {
+                self.fold_constants_in_expr(value);
+                for arm in arms {
+                    if let Some(guard) = &mut arm.guard {
+                        self.fold_constants_in_expr(guard);
+                    }
+                    self.fold_constants_in_expr(&mut arm.body);
+                }
+                None
+            }
+            Expr::FString { parts } => {
+                for part in parts {
+                    if let FStringPart::Expr(expr) = part {
+                        self.fold_constants_in_expr(expr);
+                    }
+                }
+                None
+            }
+            Expr::Lambda { body, .. } => {
+                self.fold_constants_in_block(body);
+                None
+            }
+            Expr::Spawn(expr) | Expr::Await(expr) => {
+                self.fold_constants_in_expr(expr);
+                None
+            }
+            Expr::Struct { fields, .. } => {
+                for (_, value) in fields {
+                    self.fold_constants_in_expr(value);
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn eval_unary(op: UnaryOp, literal: &Literal) -> Option<Literal> {
+        match (op, literal) {
+            (UnaryOp::Not, Literal::Bool(value)) => Some(Literal::Bool(!value)),
+            (UnaryOp::Neg, Literal::Number(num)) => Some(Literal::Number(NumberLiteral::new(
+                -num.value,
+                num.is_float_literal,
+            ))),
+            _ => None,
+        }
+    }
+
+    fn eval_binary(op: BinaryOp, left: &Literal, right: &Literal) -> Option<Literal> {
+        match op {
+            BinaryOp::Add => Self::eval_arithmetic(left, right, |a, b| a + b),
+            BinaryOp::Sub => Self::eval_arithmetic(left, right, |a, b| a - b),
+            BinaryOp::Mul => Self::eval_arithmetic(left, right, |a, b| a * b),
+            BinaryOp::Div => {
+                if matches!(right, Literal::Number(n) if n.value == 0.0) {
+                    None
+                } else {
+                    Self::eval_arithmetic(left, right, |a, b| a / b)
+                }
+            }
+            BinaryOp::Mod => Self::eval_arithmetic(left, right, |a, b| a % b),
+            BinaryOp::And => match (left, right) {
+                (Literal::Bool(a), Literal::Bool(b)) => Some(Literal::Bool(*a && *b)),
+                _ => None,
+            },
+            BinaryOp::Or => match (left, right) {
+                (Literal::Bool(a), Literal::Bool(b)) => Some(Literal::Bool(*a || *b)),
+                _ => None,
+            },
+            BinaryOp::Eq => Some(Literal::Bool(left == right)),
+            BinaryOp::Ne => Some(Literal::Bool(left != right)),
+            BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq => {
+                if let (Literal::Number(a), Literal::Number(b)) = (left, right) {
+                    let result = match op {
+                        BinaryOp::Lt => a.value < b.value,
+                        BinaryOp::Gt => a.value > b.value,
+                        BinaryOp::LtEq => a.value <= b.value,
+                        BinaryOp::GtEq => a.value >= b.value,
+                        _ => unreachable!(),
+                    };
+                    Some(Literal::Bool(result))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn eval_arithmetic<F>(left: &Literal, right: &Literal, op: F) -> Option<Literal>
+    where
+        F: Fn(f64, f64) -> f64,
+    {
+        if let (Literal::Number(a), Literal::Number(b)) = (left, right) {
+            let value = op(a.value, b.value);
+            Some(Literal::Number(NumberLiteral::new(
+                value,
+                a.is_float_literal || b.is_float_literal,
+            )))
+        } else {
+            None
+        }
+    }
+
+    fn simplify_statement(&self, stmt: Statement) -> StatementTransform {
+        match stmt {
+            Statement::Pass => StatementTransform::None,
+            Statement::If {
+                cond,
+                then_block,
+                elif_blocks,
+                else_block,
+            } => {
+                if let Expr::Literal(Literal::Bool(value)) = *cond {
+                    if value {
+                        StatementTransform::Many(then_block.statements)
+                    } else if let Some(block) = else_block {
+                        StatementTransform::Many(block.statements)
+                    } else {
+                        StatementTransform::None
+                    }
+                } else if elif_blocks.is_empty()
+                    && else_block
+                        .as_ref()
+                        .map(|block| block.statements.is_empty())
+                        .unwrap_or(true)
+                    && then_block.statements.is_empty()
+                {
+                    StatementTransform::None
+                } else {
+                    StatementTransform::Single(Statement::If {
+                        cond,
+                        then_block,
+                        elif_blocks,
+                        else_block,
+                    })
+                }
+            }
+            Statement::Block(block) if block.statements.is_empty() => StatementTransform::None,
+            other => StatementTransform::Single(other),
+        }
+    }
+
+    fn remove_dead_statements(&self, block: &mut Block) {
+        let mut pruned = Vec::with_capacity(block.statements.len());
+        let mut terminated = false;
+
+        for stmt in block.statements.drain(..) {
+            if terminated {
+                break;
+            }
+            terminated = matches!(
+                stmt,
+                Statement::Return(_) | Statement::Break | Statement::Continue
+            );
+            pruned.push(stmt);
+        }
+
+        block.statements = pruned;
+
+        for stmt in &mut block.statements {
+            match stmt {
+                Statement::If {
+                    then_block,
+                    elif_blocks,
+                    else_block,
+                    ..
+                } => {
+                    self.remove_dead_statements(then_block);
+                    for (_, block) in elif_blocks {
+                        self.remove_dead_statements(block);
+                    }
+                    if let Some(block) = else_block {
+                        self.remove_dead_statements(block);
+                    }
+                }
+                Statement::While { body, .. }
+                | Statement::For { body, .. }
+                | Statement::Block(body) => self.remove_dead_statements(body),
+                Statement::Try {
+                    body,
+                    handlers,
+                    else_block,
+                    finally_block,
+                } => {
+                    self.remove_dead_statements(body);
+                    for handler in handlers {
+                        self.remove_dead_statements(&mut handler.body);
+                    }
+                    if let Some(block) = else_block {
+                        self.remove_dead_statements(block);
+                    }
+                    if let Some(block) = finally_block {
+                        self.remove_dead_statements(block);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn prune_empty_blocks(&self, block: &mut Block) {
+        let mut flattened = Vec::with_capacity(block.statements.len());
+        for mut stmt in block.statements.drain(..) {
+            match &mut stmt {
+                Statement::Block(inner) => {
+                    self.prune_empty_blocks(inner);
+                    if inner.statements.is_empty() {
+                        continue;
+                    }
+                    flattened.push(Statement::Block(inner.clone()));
+                }
+                Statement::If {
+                    then_block,
+                    elif_blocks,
+                    else_block,
+                    ..
+                } => {
+                    self.prune_empty_blocks(then_block);
+                    for (_, block) in elif_blocks {
+                        self.prune_empty_blocks(block);
+                    }
+                    if let Some(block) = else_block {
+                        self.prune_empty_blocks(block);
+                    }
+                    flattened.push(stmt);
+                }
+                Statement::While { body, .. } | Statement::For { body, .. } => {
+                    self.prune_empty_blocks(body);
+                    flattened.push(stmt);
+                }
+                Statement::Try {
+                    body,
+                    handlers,
+                    else_block,
+                    finally_block,
+                } => {
+                    self.prune_empty_blocks(body);
+                    for handler in handlers {
+                        self.prune_empty_blocks(&mut handler.body);
+                    }
+                    if let Some(block) = else_block {
+                        self.prune_empty_blocks(block);
+                    }
+                    if let Some(block) = finally_block {
+                        self.prune_empty_blocks(block);
+                    }
+                    flattened.push(stmt);
+                }
+                _ => flattened.push(stmt),
+            }
+        }
+        block.statements = flattened;
     }
 }
 
@@ -53,4 +524,10 @@ impl Default for Reoptimizer {
     fn default() -> Self {
         Self::new()
     }
+}
+
+enum StatementTransform {
+    Single(Statement),
+    Many(Vec<Statement>),
+    None,
 }


### PR DESCRIPTION
- Added support for Cranelift as an alternative code generation backend.
- Introduced a new feature flag `cranelift-backend` to enable Cranelift.
- Updated CLI to allow selection between LLVM and Cranelift backends.
- Refactored code generation functions to accommodate backend selection.
- Enhanced optimization processes for hot paths and inlining.
- Introduced async/await functionality in the standard library with task management.
- Updated dependencies in Cargo.toml and Cargo.lock for new features.