### PR TITLE
code refactored to use updated ast

### DIFF
--- a/crates/common/src/span.rs
+++ b/crates/common/src/span.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
     start: usize,
@@ -34,8 +36,14 @@ impl Span {
     }
 }
 
-impl From<Span> for std::ops::Range<usize> {
+impl From<Span> for Range<usize> {
     fn from(span: Span) -> Self {
         span.start..span.end
+    }
+}
+
+impl From<Range<usize>> for Span {
+    fn from(range: Range<usize>) -> Self {
+        Span::new(range.start, range.end)
     }
 }

--- a/crates/module/src/processor.rs
+++ b/crates/module/src/processor.rs
@@ -34,9 +34,9 @@ impl ModuleProcessor {
         self.load_default_modules(&mut dependencies)?;
 
         for statement in &program.statements {
-            if let Statement::Use { imports } = statement {
+            if let Statement::Use { imports } = statement.as_ref() {
                 for import in imports {
-                    let module = &import.module;
+                    let module = &import.as_ref().module;
                     let module_path = ModulePath::from_string(module, &self.source_dir)?;
 
                     match module_path {
@@ -99,9 +99,9 @@ impl ModuleProcessor {
         self.load_default_modules(&mut dependencies)?;
 
         for statement in &module_statements {
-            if let Statement::Use { imports } = statement {
+            if let Statement::Use { imports } = statement.as_ref() {
                 for import in imports {
-                    let module = &import.module;
+                    let module = &import.as_ref().module;
                     let module_dir = module_path.parent().unwrap_or(Path::new("."));
                     let module_path_enum = ModulePath::from_string(module, module_dir)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -910,15 +910,15 @@ fn collect_rust_imports_for_typecheck(
     for statement in &program.statements {
         if let Statement::Use {
             imports: use_imports,
-        } = statement
+        } = statement.as_ref()
         {
             for import in use_imports {
-                if let Some((namespace, crate_name)) = import.module.split_once(':')
+                if let Some((namespace, crate_name)) = import.as_ref().module.split_once(':')
                     && namespace == "rust"
                 {
                     let aliases = imports.entry(crate_name.to_string()).or_default();
                     aliases.insert(crate_name.to_string());
-                    if let Some(alias_name) = &import.alias {
+                    if let Some(alias_name) = &import.as_ref().alias {
                         aliases.insert(alias_name.clone());
                     }
                 }

--- a/src/codegen/llvm/bridges.rs
+++ b/src/codegen/llvm/bridges.rs
@@ -53,15 +53,15 @@ fn collect_rust_imports(program: &Program) -> HashMap<String, HashSet<String>> {
     for statement in &program.statements {
         if let Statement::Use {
             imports: use_imports,
-        } = statement
+        } = statement.as_ref()
         {
             for import in use_imports {
-                if let Some((namespace, crate_name)) = import.module.split_once(':')
+                if let Some((namespace, crate_name)) = import.as_ref().module.split_once(':')
                     && namespace == "rust"
                 {
                     let aliases = imports.entry(crate_name.to_string()).or_default();
                     aliases.insert(crate_name.to_string());
-                    if let Some(alias_name) = &import.alias {
+                    if let Some(alias_name) = &import.as_ref().alias {
                         aliases.insert(alias_name.clone());
                     }
                 }

--- a/src/runtime/jit/specialization/constant_prop.rs
+++ b/src/runtime/jit/specialization/constant_prop.rs
@@ -10,7 +10,7 @@ impl ConstantPropagator {
         match expr {
             Expr::Call { args, .. } => args
                 .iter()
-                .map(|arg| self.extract_constant_from_expr(arg))
+                .map(|arg| self.extract_constant_from_expr(arg.as_ref()))
                 .collect(),
             _ => Vec::new(),
         }
@@ -18,7 +18,7 @@ impl ConstantPropagator {
 
     fn extract_constant_from_expr(&self, expr: &Expr) -> Option<RuntimeConstant> {
         match expr {
-            Expr::Literal(lit) => self.literal_to_constant(lit),
+            Expr::Literal(lit) => self.literal_to_constant(lit.as_ref()),
             _ => None,
         }
     }
@@ -52,7 +52,7 @@ impl ConstantPropagator {
     /// Fold a constant expression to its value
     pub fn fold(&self, expr: &Expr) -> Option<RuntimeConstant> {
         match expr {
-            Expr::Literal(lit) => self.literal_to_constant(lit),
+            Expr::Literal(lit) => self.literal_to_constant(lit.as_ref()),
             _ => None,
         }
     }

--- a/src/runtime/jit/specialization/type_tracker.rs
+++ b/src/runtime/jit/specialization/type_tracker.rs
@@ -1,5 +1,5 @@
 use super::RuntimeType;
-use ast::nodes::Expr;
+use ast::nodes::{Expr, Literal};
 
 /// Tracks runtime types for specialization
 pub struct TypeTracker {
@@ -22,10 +22,10 @@ impl TypeTracker {
     /// Infer runtime type from expression
     pub fn infer_type(&mut self, expr: &Expr) -> RuntimeType {
         match expr {
-            Expr::Literal(lit) => match lit {
-                ast::nodes::Literal::Bool(_) => RuntimeType::Bool,
-                ast::nodes::Literal::Number(_) => RuntimeType::F64, // Default to float
-                ast::nodes::Literal::String(_) => RuntimeType::Str,
+            Expr::Literal(lit) => match lit.as_ref() {
+                Literal::Bool(_) => RuntimeType::Bool,
+                Literal::Number(_) => RuntimeType::F64, // Default to float
+                Literal::String(_) => RuntimeType::Str,
                 _ => RuntimeType::Unknown,
             },
             Expr::Identifier { .. } => RuntimeType::Unknown, // Would need symbol table lookup

--- a/src/test/discovery.rs
+++ b/src/test/discovery.rs
@@ -63,14 +63,14 @@ impl TestDiscovery {
         let mut tests = Vec::new();
 
         for (idx, stmt) in program.statements.iter().enumerate() {
-            if let Statement::Function(func) = stmt
-                && Self::is_test_function(func)
+            if let Statement::Function(func) = stmt.as_ref()
+                && Self::is_test_function(func.as_ref())
             {
                 let line_number = Self::estimate_line_number(&source, idx);
                 tests.push(TestCase {
                     file_path: file_path.to_path_buf(),
-                    function_name: func.name.clone(),
-                    function: func.clone(),
+                    function_name: func.as_ref().name.clone(),
+                    function: func.as_ref().clone(),
                     line_number,
                 });
             }

--- a/src/typecheck/types.rs
+++ b/src/typecheck/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ast::nodes::{EnumVariant, Type};
+use ast::nodes::{EnumVariant, Node, Type};
 use common::Span;
 
 use language::LanguageFeatureFlags;
@@ -413,6 +413,12 @@ impl From<&Type> for TypeInfo {
     }
 }
 
+impl From<&Node<Type>> for TypeInfo {
+    fn from(node: &Node<Type>) -> Self {
+        TypeInfo::from(node.as_ref())
+    }
+}
+
 impl From<&str> for TypeInfo {
     fn from(name: &str) -> Self {
         match name {
@@ -670,7 +676,7 @@ impl TypeContext {
         }
     }
 
-    pub fn type_from_annotation(&self, ty: &Type) -> TypeInfo {
+    pub fn type_from_annotation(&self, ty: &Node<Type>) -> TypeInfo {
         let mut info = TypeInfo::from(ty);
         if let TypeInfo::Generic { base, args } = &info
             && args.is_empty()


### PR DESCRIPTION
This MR refactors the AST to wrap nodes in a new `Node` type that contains a `span` so that there is a span associated with every node. This will enable better error messages in the type checker and likely elsewhere.