### PR TITLE
fix: two edge cases in match parsing

### DIFF
--- a/crates/lexer/src/tokenizer.rs
+++ b/crates/lexer/src/tokenizer.rs
@@ -830,12 +830,20 @@ impl LexerState {
     }
 
     fn finalize_indentation(&mut self) {
+        // Insert an extra newline to prevent parsing errors
+        self.tokens.push(Token::new(
+            TokenKind::Newline,
+            Span::new(self.offset, self.offset),
+        ));
+
+        // Dedent to base level
         while self.indent_stack.len() > 1 {
             self.indent_stack.pop();
             let span = Span::new(self.offset, self.offset);
             self.tokens.push(Token::new(TokenKind::Dedent, span));
         }
 
+        // Add EOF token
         let eof_span = Span::new(self.offset, self.offset);
         self.tokens.push(Token::new(TokenKind::Eof, eof_span));
     }


### PR DESCRIPTION
This fixed a couple of edge cases in match parsing where parsing would fail. The culprit ended up being in the lexer, where dedent tokens are added to the end of the file. The match parsing did not account for those extra dedents at the end of a file, only expecting a single dedent. This was fixed by adding a newline token before the dedent tokens at the end of a file.

Fixes #54 