### PR TITLE
fix: remove redundant .into_iter() in enum field loop

### DIFF
--- a/crates/otterc_codegen/src/llvm/compiler/expr.rs
+++ b/crates/otterc_codegen/src/llvm/compiler/expr.rs
@@ -3094,7 +3094,7 @@ impl<'ctx> Compiler<'ctx> {
             .left()
             .ok_or_else(|| anyhow!("runtime.enum.create returned void"))?;
 
-        for (index, (field_type, value)) in field_types.iter().zip(values.into_iter()).enumerate() {
+        for (index, (field_type, value)) in field_types.iter().zip(values).enumerate() {
             self.store_enum_field(handle, index as u32, field_type, value)?;
         }
 


### PR DESCRIPTION
`zip` accepts any `IntoIterator` so calling `.into_iter()` explicitly on the `values` argument is unnecessary — clippy `useless_conversion`.

**File changed:** `crates/otterc_codegen/src/llvm/compiler/expr.rs` (1 line)

**Tests:** ran `cargo +nightly test` across otterc_module, otterc_parser, otterc_lexer, otterc_ffi, otterc_ast, otterc_span. 10 passed / 1 failed before and after (the failing test is pre-existing and unrelated). No new failures introduced.

**Not changed:** behaviour, public API, any other clippy warnings.